### PR TITLE
feat: 유저 회원가입 기능 추가

### DIFF
--- a/src/main/java/com/wanted/budgetmanagement/api/user/controller/UserController.java
+++ b/src/main/java/com/wanted/budgetmanagement/api/user/controller/UserController.java
@@ -1,0 +1,38 @@
+package com.wanted.budgetmanagement.api.user.controller;
+
+import com.wanted.budgetmanagement.api.user.dto.UserSignUpRequest;
+import com.wanted.budgetmanagement.api.user.service.UserService;
+import com.wanted.budgetmanagement.global.exception.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/users")
+@Tag(name = "Users", description = "Users API")
+public class UserController {
+
+    private final UserService userService;
+
+    @Operation(summary = "User 회원가입 API", responses = {
+            @ApiResponse(responseCode = "201")
+    })
+    @Tag(name = "Users")
+    @PostMapping
+    public ResponseEntity userSignUp(@Validated @RequestBody UserSignUpRequest request) {
+        userService.userSignUp(request);
+
+        return ResponseEntity.created(URI.create("/api/users")).body(new BaseResponse(201, "유저 회원가입에 성공했습니다."));
+    }
+
+}

--- a/src/main/java/com/wanted/budgetmanagement/api/user/dto/UserSignUpRequest.java
+++ b/src/main/java/com/wanted/budgetmanagement/api/user/dto/UserSignUpRequest.java
@@ -1,0 +1,23 @@
+package com.wanted.budgetmanagement.api.user.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserSignUpRequest {
+
+    @Schema(description = "이메일", example = "example@gmail.com")
+    @NotBlank(message = "이메일을 입력하세요.")
+    @Email
+    private String email;
+
+    @Schema(description = "비밀번호", example = "example12345")
+    @NotBlank(message = "비밀번호를 입력하세요.")
+    private String password;
+}

--- a/src/main/java/com/wanted/budgetmanagement/api/user/service/UserService.java
+++ b/src/main/java/com/wanted/budgetmanagement/api/user/service/UserService.java
@@ -1,0 +1,50 @@
+package com.wanted.budgetmanagement.api.user.service;
+
+import com.wanted.budgetmanagement.api.user.dto.UserSignUpRequest;
+import com.wanted.budgetmanagement.domain.user.entity.User;
+import com.wanted.budgetmanagement.domain.user.repository.UserRepository;
+import com.wanted.budgetmanagement.global.exception.BaseException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.wanted.budgetmanagement.global.exception.BaseExceptionStatus.DUPLICATE_EMAIL;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    private final PasswordEncoder encoder;
+
+    /**
+     * 유저 회원가입
+     * 중복된 email인지 확인 후 입력 받은 password를 암호화 해서 유저를 저장한다.
+     * @param request : email, password
+     */
+    @Transactional
+    public void userSignUp(UserSignUpRequest request) {
+        emailDuplicateCheck(request.getEmail());
+
+        String enPassword = encoder.encode(request.getPassword());
+
+        User user = User.builder()
+                .email(request.getEmail())
+                .password(enPassword)
+                .build();
+
+        userRepository.save(user);
+    }
+
+    /**
+     * 중복된 이메일 이라면 예외를 던져주고, 그렇지 않다면 false를 리턴합니다.
+     */
+    private boolean emailDuplicateCheck(String email) {
+        if (userRepository.existsByEmail(email)) {
+            throw new BaseException(DUPLICATE_EMAIL);
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/wanted/budgetmanagement/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/wanted/budgetmanagement/domain/user/repository/UserRepository.java
@@ -4,4 +4,6 @@ import com.wanted.budgetmanagement.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User,Long> {
+
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/com/wanted/budgetmanagement/global/exception/BaseExceptionStatus.java
+++ b/src/main/java/com/wanted/budgetmanagement/global/exception/BaseExceptionStatus.java
@@ -7,7 +7,9 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum BaseExceptionStatus {
-;
+
+    DUPLICATE_EMAIL(HttpStatus.CONFLICT, "중복된 이메일이 있습니다.");
+
     private final HttpStatus code;
     private final String message;
 }

--- a/src/test/java/com/wanted/budgetmanagement/api/user/controller/UserControllerTest.java
+++ b/src/test/java/com/wanted/budgetmanagement/api/user/controller/UserControllerTest.java
@@ -1,0 +1,88 @@
+package com.wanted.budgetmanagement.api.user.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wanted.budgetmanagement.api.user.dto.UserSignUpRequest;
+import com.wanted.budgetmanagement.domain.user.entity.User;
+import com.wanted.budgetmanagement.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Transactional
+@AutoConfigureMockMvc
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+class UserControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder encoder;
+
+    @DisplayName("테스트에 필요한 User 저장")
+    void before() {
+        userRepository.save(User.builder()
+                .email("email@gmail.com")
+                .password(encoder.encode("password123"))
+                .build());
+    }
+
+    @DisplayName("유저 회원가입 성공")
+    @Test
+    void userSignUp() throws Exception {
+        // given
+        UserSignUpRequest request = new UserSignUpRequest("email@gmail.com", "password123");
+        String content = new ObjectMapper().writeValueAsString(request);
+
+        // when
+        ResultActions resultActions = mvc.perform(post("/api/users")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(content)
+                .accept(MediaType.APPLICATION_JSON)
+                .characterEncoding("UTF-8")
+        );
+
+        // then
+        resultActions.andExpect(status().isCreated())
+                .andExpect(jsonPath("code").value("201"))
+                .andExpect(jsonPath("message").value("유저 회원가입에 성공했습니다."));
+    }
+
+    @DisplayName("유저 회원가입 실패")
+    @Test
+    void userSignUpFail() throws Exception {
+        // 테스트에 필요한 유저 저장
+        before();
+        // given
+        UserSignUpRequest request = new UserSignUpRequest("email@gmail.com", "password123");
+        String content = new ObjectMapper().writeValueAsString(request);
+
+        // when
+        ResultActions resultActions = mvc.perform(post("/api/users")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(content)
+                .accept(MediaType.APPLICATION_JSON)
+                .characterEncoding("UTF-8")
+        );
+
+        // then
+        resultActions.andExpect(status().isConflict())
+                .andExpect(jsonPath("code").value("409"))
+                .andExpect(jsonPath("message").value("중복된 이메일이 있습니다."));
+    }
+}

--- a/src/test/java/com/wanted/budgetmanagement/api/user/service/UserServiceTest.java
+++ b/src/test/java/com/wanted/budgetmanagement/api/user/service/UserServiceTest.java
@@ -1,0 +1,56 @@
+package com.wanted.budgetmanagement.api.user.service;
+
+import com.wanted.budgetmanagement.api.user.dto.UserSignUpRequest;
+import com.wanted.budgetmanagement.domain.user.repository.UserRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@Transactional
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+
+    @InjectMocks
+    private UserService userService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder encoder;
+
+    @DisplayName("유저 회원가입 성공")
+    @Test
+    void userSignUp() {
+        // given
+        UserSignUpRequest request = new UserSignUpRequest("email@gmail.com", "password12");
+
+        // when
+        userService.userSignUp(request);
+    }
+
+    @DisplayName("유저 회원가입 실패")
+    @Test
+    void userSignUpFail() {
+        // given
+        UserSignUpRequest request = new UserSignUpRequest("email@gmail.com", "password12");
+
+        // stub
+        when(userRepository.existsByEmail(request.getEmail())).thenReturn(true);
+        // when
+
+        // then
+        assertThatThrownBy(() -> userService.userSignUp(request)).hasMessage("중복된 이메일이 있습니다.");
+    }
+}

--- a/src/test/java/com/wanted/budgetmanagement/domain/user/repository/UserRepositoryTest.java
+++ b/src/test/java/com/wanted/budgetmanagement/domain/user/repository/UserRepositoryTest.java
@@ -1,0 +1,44 @@
+package com.wanted.budgetmanagement.domain.user.repository;
+
+import com.wanted.budgetmanagement.domain.user.entity.User;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@DataJpaTest
+class UserRepositoryTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @DisplayName("유저 저장 성공")
+    @Test
+    void userSignUp() {
+        // given
+        String email = "email@gmail.com";
+        String password = "password";
+        User user = User.builder()
+                .email(email)
+                .password(password)
+                .build();
+
+        // when
+        User saveUser = userRepository.save(user);
+
+        // then
+        assertAll(
+                () -> assertThat(user.getId()).isEqualTo(saveUser.getId()),
+                () -> assertThat(user.getEmail()).isEqualTo(saveUser.getEmail()),
+                () -> assertThat(user.getPassword()).isEqualTo(saveUser.getPassword()),
+                () -> assertThat(user.getRefresh_token()).isEqualTo(saveUser.getRefresh_token())
+        );
+
+    }
+}


### PR DESCRIPTION
## 작업 내용
- 유저 회원가입 기능 추가, 유저 회원가입 테스트 코드 추가
<br><br>

## 작업 설명
- [`01b71a9`](https://github.com/ks12b0000/wanted-pre-onboarding-budget-management/pull/15/commits/01b71a9b6d9e9fd3422b882fec2cce101061c0f6): UserSignUpRequest에 email, password로 유저가 회원가입을 한다. 만약 중복된 이메일을 입력했다면 DUPLICATE_EMAIL(중복된 이메일이 있습니다.) 예외 발생.
- [`93d52f5`](https://github.com/ks12b0000/wanted-pre-onboarding-budget-management/pull/15/commits/93d52f5c94ab00263332ea352b23f636f9b9b79d): UserRepository, UserService, UserController에 회원가입 성공, 실패 테스트 코드 추가.
<br><br> 

## 테스트
- 회원가입 성공
<img width="1377" alt="스크린샷 2023-11-10 오후 4 46 22" src="https://github.com/ks12b0000/wanted-pre-onboarding-budget-management/assets/102012155/4e02085e-90a9-486a-a3e5-bbf236b3afb0">

- 회원가입 실패
<img width="1385" alt="스크린샷 2023-11-10 오후 4 46 48" src="https://github.com/ks12b0000/wanted-pre-onboarding-budget-management/assets/102012155/bae9af17-c384-44e8-a4f2-ac43c870107f">

<img width="274" alt="스크린샷 2023-11-10 오후 4 47 18" src="https://github.com/ks12b0000/wanted-pre-onboarding-budget-management/assets/102012155/4b9df0dd-813c-4cdf-8ada-d09ceffeee54">

