### PR TITLE
feat: 예산 카테고리 목록 조회 기능 추가

### DIFF
--- a/src/main/java/com/wanted/budgetmanagement/api/budgetCategory/controller/BudgetCategoryController.java
+++ b/src/main/java/com/wanted/budgetmanagement/api/budgetCategory/controller/BudgetCategoryController.java
@@ -1,0 +1,33 @@
+package com.wanted.budgetmanagement.api.budgetCategory.controller;
+
+import com.wanted.budgetmanagement.api.budgetCategory.dto.BudgetCategoryResponse;
+import com.wanted.budgetmanagement.api.budgetCategory.service.BudgetCategoryService;
+import com.wanted.budgetmanagement.global.exception.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/budget-categories")
+@Tag(name = "budget-category", description = "budget-category API")
+public class BudgetCategoryController {
+
+    private final BudgetCategoryService categoryService;
+
+    @Operation(summary = "예산 카테고리 목록 조회 API", responses = {
+            @ApiResponse(responseCode = "200")
+    })
+    @Tag(name = "budget-category")
+    @GetMapping
+    public ResponseEntity categoryList() {
+        BudgetCategoryResponse response = categoryService.categoryList();
+
+        return ResponseEntity.ok().body(new BaseResponse(200, "카테고리 목록 조회에 성공했습니다.", response));
+    }
+}

--- a/src/main/java/com/wanted/budgetmanagement/api/budgetCategory/dto/BudgetCategoryResponse.java
+++ b/src/main/java/com/wanted/budgetmanagement/api/budgetCategory/dto/BudgetCategoryResponse.java
@@ -1,0 +1,16 @@
+package com.wanted.budgetmanagement.api.budgetCategory.dto;
+
+import com.wanted.budgetmanagement.domain.budgetCategory.entity.BudgetCategory;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BudgetCategoryResponse {
+
+    List<BudgetCategory> categories;
+}

--- a/src/main/java/com/wanted/budgetmanagement/api/budgetCategory/service/BudgetCategoryService.java
+++ b/src/main/java/com/wanted/budgetmanagement/api/budgetCategory/service/BudgetCategoryService.java
@@ -1,0 +1,29 @@
+package com.wanted.budgetmanagement.api.budgetCategory.service;
+
+import com.wanted.budgetmanagement.api.budgetCategory.dto.BudgetCategoryResponse;
+import com.wanted.budgetmanagement.domain.budgetCategory.entity.BudgetCategory;
+import com.wanted.budgetmanagement.domain.budgetCategory.repository.BudgetCategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class BudgetCategoryService {
+
+    private final BudgetCategoryRepository categoryRepository;
+
+    /**
+     * 예산 카테고리 목록 조회
+     * 전체 예산 카테고리 목록을 불러와서 BudgetCategoryResponse를 반환한다.
+     * @return
+     */
+    public BudgetCategoryResponse categoryList() {
+        List<BudgetCategory> list = categoryRepository.findAll();
+
+        BudgetCategoryResponse response = new BudgetCategoryResponse(list);
+
+        return response;
+    }
+}

--- a/src/main/java/com/wanted/budgetmanagement/domain/budgetCategory/repository/BudgetCategoryRepository.java
+++ b/src/main/java/com/wanted/budgetmanagement/domain/budgetCategory/repository/BudgetCategoryRepository.java
@@ -1,7 +1,8 @@
 package com.wanted.budgetmanagement.domain.budgetCategory.repository;
 
+import com.wanted.budgetmanagement.domain.budgetCategory.entity.BudgetCategory;
 import com.wanted.budgetmanagement.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface BudgetCategoryRepository extends JpaRepository<User,Long> {
+public interface BudgetCategoryRepository extends JpaRepository<BudgetCategory,Long> {
 }

--- a/src/main/java/com/wanted/budgetmanagement/global/config/SwaggerConfig.java
+++ b/src/main/java/com/wanted/budgetmanagement/global/config/SwaggerConfig.java
@@ -1,0 +1,26 @@
+package com.wanted.budgetmanagement.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Arrays;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI(){
+        SecurityScheme securityScheme = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP).scheme("bearer").bearerFormat("JWT")
+                .in(SecurityScheme.In.HEADER).name("Authorization");
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList("bearerAuth");
+
+        return new OpenAPI()
+                .components(new Components().addSecuritySchemes("bearerAuth", securityScheme))
+                .security(Arrays.asList(securityRequirement));
+    }
+}

--- a/src/test/java/com/wanted/budgetmanagement/api/budgetCategory/controller/BudgetCategoryControllerTest.java
+++ b/src/test/java/com/wanted/budgetmanagement/api/budgetCategory/controller/BudgetCategoryControllerTest.java
@@ -1,0 +1,51 @@
+package com.wanted.budgetmanagement.api.budgetCategory.controller;
+
+import com.wanted.budgetmanagement.domain.budgetCategory.entity.BudgetCategory;
+import com.wanted.budgetmanagement.domain.budgetCategory.repository.BudgetCategoryRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Transactional
+@AutoConfigureMockMvc
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+class BudgetCategoryControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private BudgetCategoryRepository categoryRepository;
+
+    @DisplayName("예산 카테고리 목록 조회")
+    @Test
+    @WithMockUser
+    void categoryList() throws Exception {
+        // given
+        BudgetCategory category = new BudgetCategory(1L, "식비");
+        categoryRepository.save(category);
+
+        // when
+        ResultActions resultActions = mvc.perform(get("/api/budget-categories")
+                .characterEncoding("UTF-8")
+        );
+
+        // then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("code").value("200"))
+                .andExpect(jsonPath("message").value("카테고리 목록 조회에 성공했습니다."));
+
+    }
+}

--- a/src/test/java/com/wanted/budgetmanagement/api/budgetCategory/service/BudgetCategoryServiceTest.java
+++ b/src/test/java/com/wanted/budgetmanagement/api/budgetCategory/service/BudgetCategoryServiceTest.java
@@ -1,0 +1,49 @@
+package com.wanted.budgetmanagement.api.budgetCategory.service;
+
+import com.wanted.budgetmanagement.api.budgetCategory.dto.BudgetCategoryResponse;
+import com.wanted.budgetmanagement.domain.budgetCategory.entity.BudgetCategory;
+import com.wanted.budgetmanagement.domain.budgetCategory.repository.BudgetCategoryRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@Transactional
+@ExtendWith(MockitoExtension.class)
+class BudgetCategoryServiceTest {
+
+    @InjectMocks
+    private BudgetCategoryService categoryService;
+
+    @Mock
+    private BudgetCategoryRepository categoryRepository;
+
+    @DisplayName("예산 카테고리 목록 조회")
+    @Test
+    void categoryList() {
+        // given
+        BudgetCategory category = new BudgetCategory(1L, "식비");
+        List<BudgetCategory> list = new ArrayList<>();
+        list.add(category);
+
+        // stub
+        when(categoryRepository.findAll()).thenReturn(list);
+        // when
+        BudgetCategoryResponse response = categoryService.categoryList();
+
+        // then
+        assertThat(response.getCategories().get(0).getName()).isEqualTo("식비");
+    }
+
+}

--- a/src/test/java/com/wanted/budgetmanagement/domain/budgetCategory/repository/BudgetCategoryRepositoryTest.java
+++ b/src/test/java/com/wanted/budgetmanagement/domain/budgetCategory/repository/BudgetCategoryRepositoryTest.java
@@ -1,0 +1,36 @@
+package com.wanted.budgetmanagement.domain.budgetCategory.repository;
+
+import com.wanted.budgetmanagement.domain.budgetCategory.entity.BudgetCategory;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@DataJpaTest
+class BudgetCategoryRepositoryTest {
+
+    @Autowired
+    private BudgetCategoryRepository categoryRepository;
+
+    @DisplayName("예산 카테고리 목록 전체 조회")
+    @Test
+    void categoryList() {
+        // given
+        BudgetCategory category = new BudgetCategory(1L, "식비");
+        categoryRepository.save(category);
+
+        // when
+        List<BudgetCategory> list = categoryRepository.findAll();
+
+        // then
+        assertThat(list.get(0).getName()).isEqualTo("식비");
+    }
+
+}


### PR DESCRIPTION
## 작업 내용
- 예산 카테고리 목록 조회 기능 추가, 예산 카테고리 목록 조회 테스트 코드 추가
<br><br>

## 작업 설명
- [`069af58`](https://github.com/ks12b0000/wanted-pre-onboarding-budget-management/pull/17/commits/069af5800acaa627d79a9652771a7596e4b7ecef): 예산 카테고리 전체 목록을 조회합니다.
- [`5a72e24`](https://github.com/ks12b0000/wanted-pre-onboarding-budget-management/pull/17/commits/5a72e2431efa305bf7f691c1e81ef2447e4b0893): BudgetCategoryControllerTest, BudgetCategoryRepositoryTest, BudgetCategoryServiceTest에 예산 카테고리 목록 조회 성공 테스트 코드 추가
<br><br>

## 테스트
- 예산 카테고리 목록 조회 성공
<img width="1383" alt="스크린샷 2023-11-11 오후 7 09 44" src="https://github.com/ks12b0000/wanted-pre-onboarding-budget-management/assets/102012155/76235475-c437-4052-a1d5-0e2469e4ce08">

