### PR TITLE
feat: 예산 설정 기능 추가

### DIFF
--- a/src/main/java/com/wanted/budgetmanagement/api/budget/controller/BudgetController.java
+++ b/src/main/java/com/wanted/budgetmanagement/api/budget/controller/BudgetController.java
@@ -1,0 +1,37 @@
+package com.wanted.budgetmanagement.api.budget.controller;
+
+import com.wanted.budgetmanagement.api.budget.dto.BudgetSettingRequest;
+import com.wanted.budgetmanagement.api.budget.service.BudgetService;
+import com.wanted.budgetmanagement.domain.user.entity.User;
+import com.wanted.budgetmanagement.global.exception.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/budgets")
+@Tag(name = "Budgets", description = "Budgets API")
+public class BudgetController {
+
+    private final BudgetService budgetService;
+
+    @Operation(summary = "Budget 설정 API", responses = {
+            @ApiResponse(responseCode = "200")
+    })
+    @Tag(name = "Budgets")
+    @PostMapping
+    public ResponseEntity budgetSetting(@RequestBody BudgetSettingRequest request, @AuthenticationPrincipal User user) {
+        budgetService.budgetSetting(request, user);
+
+        return ResponseEntity.ok().body(new BaseResponse<>(200, "예산 설정에 성공했습니다."));
+    }
+
+}

--- a/src/main/java/com/wanted/budgetmanagement/api/budget/dto/BudgetSettingRequest.java
+++ b/src/main/java/com/wanted/budgetmanagement/api/budget/dto/BudgetSettingRequest.java
@@ -1,0 +1,31 @@
+package com.wanted.budgetmanagement.api.budget.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.YearMonth;
+import java.util.Date;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class BudgetSettingRequest {
+
+    @Schema(description = "설정 예산", example = "100000")
+    @NotBlank(message = "예산을 입력해주세요.")
+    private int money;
+
+    @Schema(description = "예산 카테고리", example = "식비")
+    @NotBlank(message = "카테고리를 입력해주세요")
+    private String categoryName;
+
+    @Schema(description = "기간", example = "2023-11")
+    @NotBlank(message = "기간을 설정해주세요.")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM", timezone = "Asia/Seoul")
+    private Date period;
+}

--- a/src/main/java/com/wanted/budgetmanagement/api/budget/service/BudgetService.java
+++ b/src/main/java/com/wanted/budgetmanagement/api/budget/service/BudgetService.java
@@ -1,0 +1,42 @@
+package com.wanted.budgetmanagement.api.budget.service;
+
+import com.wanted.budgetmanagement.api.budget.dto.BudgetSettingRequest;
+import com.wanted.budgetmanagement.domain.budget.entity.Budget;
+import com.wanted.budgetmanagement.domain.budget.repository.BudgetRepository;
+import com.wanted.budgetmanagement.domain.budgetCategory.entity.BudgetCategory;
+import com.wanted.budgetmanagement.domain.budgetCategory.repository.BudgetCategoryRepository;
+import com.wanted.budgetmanagement.domain.user.entity.User;
+import com.wanted.budgetmanagement.global.exception.BaseException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+import static com.wanted.budgetmanagement.global.exception.BaseExceptionStatus.NON_EXISTENT_CATEGORY;
+
+@Service
+@RequiredArgsConstructor
+public class BudgetService {
+
+    private final BudgetRepository budgetRepository;
+
+    private final BudgetCategoryRepository categoryRepository;
+
+    /**
+     * request에서 받은 categoryName으로 카테고리를 조회 후 존재하지 않은 카테고리면 예외처리하고,
+     * request에서 받은 값들을 저장한다.
+     * @param request : money, categoryName, period
+     * @param user
+     */
+    public void budgetSetting(BudgetSettingRequest request, User user) {
+        BudgetCategory category = categoryRepository.findByName(request.getCategoryName()).orElseThrow(() -> new BaseException(NON_EXISTENT_CATEGORY));
+        Budget budget = Budget.builder()
+                .category(category)
+                .money(request.getMoney())
+                .period(request.getPeriod())
+                .user(user)
+                .build();
+
+        budgetRepository.save(budget);
+    }
+}

--- a/src/main/java/com/wanted/budgetmanagement/domain/budgetCategory/repository/BudgetCategoryRepository.java
+++ b/src/main/java/com/wanted/budgetmanagement/domain/budgetCategory/repository/BudgetCategoryRepository.java
@@ -4,5 +4,9 @@ import com.wanted.budgetmanagement.domain.budgetCategory.entity.BudgetCategory;
 import com.wanted.budgetmanagement.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface BudgetCategoryRepository extends JpaRepository<BudgetCategory,Long> {
+
+    Optional<BudgetCategory> findByName(String name);
 }

--- a/src/main/java/com/wanted/budgetmanagement/global/exception/BaseExceptionStatus.java
+++ b/src/main/java/com/wanted/budgetmanagement/global/exception/BaseExceptionStatus.java
@@ -10,7 +10,8 @@ public enum BaseExceptionStatus {
 
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "중복된 이메일이 있습니다."),
     NON_EXISTENT_USER(HttpStatus.BAD_REQUEST, "존재하지 않는 유저입니다."),
-    LOGIN_USER_NOT_EXIST(HttpStatus.BAD_REQUEST, "아이디 또는 비밀번호가 일치하지 않습니다.");
+    LOGIN_USER_NOT_EXIST(HttpStatus.BAD_REQUEST, "아이디 또는 비밀번호가 일치하지 않습니다."),
+    NON_EXISTENT_CATEGORY(HttpStatus.BAD_REQUEST, "존재하지 않는 카테고리입니다.");
 
     private final HttpStatus code;
     private final String message;

--- a/src/test/java/com/wanted/budgetmanagement/api/budget/controller/BudgetControllerTest.java
+++ b/src/test/java/com/wanted/budgetmanagement/api/budget/controller/BudgetControllerTest.java
@@ -1,0 +1,83 @@
+package com.wanted.budgetmanagement.api.budget.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wanted.budgetmanagement.api.budget.dto.BudgetSettingRequest;
+import com.wanted.budgetmanagement.domain.budgetCategory.entity.BudgetCategory;
+import com.wanted.budgetmanagement.domain.budgetCategory.repository.BudgetCategoryRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Transactional
+@AutoConfigureMockMvc
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+class BudgetControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private BudgetCategoryRepository categoryRepository;
+
+    @DisplayName("예산 설정 성공")
+    @Test
+    @WithMockUser
+    void budgetSetting() throws Exception {
+        // given
+        BudgetCategory category = new BudgetCategory(1L, "식비");
+        categoryRepository.save(category);
+        BudgetSettingRequest request = new BudgetSettingRequest(100000, "식비", new Date(202311));
+        String content = new ObjectMapper().writeValueAsString(request);
+
+        // when
+        ResultActions resultActions = mvc.perform(post("/api/budgets")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(content)
+                .accept(MediaType.APPLICATION_JSON)
+                .characterEncoding("UTF-8")
+        );
+
+        // then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("code").value("200"))
+                .andExpect(jsonPath("message").value("예산 설정에 성공했습니다."));
+
+    }
+
+    @DisplayName("예산 설정 실패")
+    @Test
+    @WithMockUser
+    void budgetSettingFail() throws Exception {
+        // given
+        BudgetSettingRequest request = new BudgetSettingRequest(100000, "핸드폰비", new Date(202311));
+        String content = new ObjectMapper().writeValueAsString(request);
+
+        // when
+        ResultActions resultActions = mvc.perform(post("/api/budgets")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(content)
+                .accept(MediaType.APPLICATION_JSON)
+                .characterEncoding("UTF-8")
+        );
+
+        // then
+        resultActions.andExpect(status().isBadRequest())
+                .andExpect(jsonPath("code").value("400"))
+                .andExpect(jsonPath("message").value("존재하지 않는 카테고리입니다."));
+
+    }
+}

--- a/src/test/java/com/wanted/budgetmanagement/api/budget/service/BudgetServiceTest.java
+++ b/src/test/java/com/wanted/budgetmanagement/api/budget/service/BudgetServiceTest.java
@@ -1,0 +1,66 @@
+package com.wanted.budgetmanagement.api.budget.service;
+
+import com.wanted.budgetmanagement.api.budget.dto.BudgetSettingRequest;
+import com.wanted.budgetmanagement.domain.budget.repository.BudgetRepository;
+import com.wanted.budgetmanagement.domain.budgetCategory.entity.BudgetCategory;
+import com.wanted.budgetmanagement.domain.budgetCategory.repository.BudgetCategoryRepository;
+import com.wanted.budgetmanagement.domain.user.entity.User;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Date;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@Transactional
+@ExtendWith(MockitoExtension.class)
+class BudgetServiceTest {
+
+    @InjectMocks
+    private BudgetService budgetService;
+
+    @Mock
+    private BudgetRepository budgetRepository;
+
+    @Mock
+    private BudgetCategoryRepository categoryRepository;
+
+    @DisplayName("예산 설정 성공")
+    @Test
+    void budgetSetting() {
+        // given
+        BudgetCategory category = new BudgetCategory(1L, "식비");
+        BudgetSettingRequest request = new BudgetSettingRequest(100000, "식비", new Date(202311));
+        User user = new User(1L, "email@gmail.com", "password", null);
+
+        // stub
+        when(categoryRepository.findByName(request.getCategoryName())).thenReturn(Optional.of(category));
+
+        // when
+        budgetService.budgetSetting(request, user);
+    }
+
+    @DisplayName("예산 설정 실패")
+    @Test
+    void budgetSettingFail() {
+        // given
+        BudgetSettingRequest request = new BudgetSettingRequest(100000, "식비", new Date(202311));
+        User user = new User(1L, "email@gmail.com", "password", null);
+
+        // stub
+        // when
+        // then
+        assertThatThrownBy(() -> budgetService.budgetSetting(request, user)).hasMessage("존재하지 않는 카테고리입니다.");
+
+    }
+
+}

--- a/src/test/java/com/wanted/budgetmanagement/domain/budget/repository/BudgetRepositoryTest.java
+++ b/src/test/java/com/wanted/budgetmanagement/domain/budget/repository/BudgetRepositoryTest.java
@@ -1,0 +1,53 @@
+package com.wanted.budgetmanagement.domain.budget.repository;
+
+import com.wanted.budgetmanagement.domain.budget.entity.Budget;
+import com.wanted.budgetmanagement.domain.budgetCategory.entity.BudgetCategory;
+import com.wanted.budgetmanagement.domain.budgetCategory.repository.BudgetCategoryRepository;
+import com.wanted.budgetmanagement.domain.user.entity.User;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.security.test.context.support.WithMockUser;
+
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@DataJpaTest
+class BudgetRepositoryTest {
+
+    @Autowired
+    private BudgetRepository budgetRepository;
+
+    @Autowired
+    private BudgetCategoryRepository categoryRepository;
+
+    @DisplayName("예산 저장")
+    @Test
+    @WithMockUser
+    void budgetSetting() {
+        // given
+        BudgetCategory category = new BudgetCategory(1L, "식비");
+        categoryRepository.save(category);
+        Date date = new Date(20231023);
+        User user = new User(1L, "email@gmail.com", "password", null);
+        Budget budget = new Budget(1L, user, category, 100000, date);
+
+        // when
+        Budget saveBudget = budgetRepository.save(budget);
+
+        // then
+        assertAll(
+                () -> assertThat(saveBudget.getCategory().getName()).isEqualTo(budget.getCategory().getName()),
+                () -> assertThat(saveBudget.getId()).isEqualTo(budget.getId()),
+                () -> assertThat(saveBudget.getMoney()).isEqualTo(budget.getMoney()),
+                () -> assertThat(saveBudget.getUser().getId()).isEqualTo(budget.getUser().getId()),
+                () -> assertThat(saveBudget.getPeriod()).isEqualTo(budget.getPeriod())
+        );
+    }
+}


### PR DESCRIPTION
## 작업 내용
- 예산 설정 기능 추가, 예산 설정 테스트 코드 추가
<br><br>

## 작업 설명
- [`92bde6c`](https://github.com/ks12b0000/wanted-pre-onboarding-budget-management/pull/18/commits/92bde6c3f82c50fb72ab9f97d44ab21d7ca9b467): BudgetSettingRequest에 money, category, period를 받고 JWT Token으로 User정보를 받아서 예산을 설정한다. 만약 존재하지 않는 카테고리의 입력이 들어오면 NON_EXISTENT_CATEGORY(존재하지 않는 카테고리입니다.) 예외 발생.
- [`680db7d`](https://github.com/ks12b0000/wanted-pre-onboarding-budget-management/pull/18/commits/680db7df13d45fa3d13de5f73fd999fc2edd173c): BudgetControllerTest, BudgetRepositoryTest, BudgetServiceTest에 예산 설정 성공, 실패 테스트 코드 추가.
<br><br>

## 테스트
- 예산 설정 성공
<img width="1386" alt="스크린샷 2023-11-12 오후 5 42 01" src="https://github.com/ks12b0000/wanted-pre-onboarding-budget-management/assets/102012155/7d000414-98b2-4927-984a-fc57a3cd2151">

- 예산 설정 실패
<img width="1383" alt="스크린샷 2023-11-12 오후 5 42 28" src="https://github.com/ks12b0000/wanted-pre-onboarding-budget-management/assets/102012155/9890384c-d691-49de-bc35-b37bf8a1d149">

<img width="274" alt="스크린샷 2023-11-12 오후 5 42 43" src="https://github.com/ks12b0000/wanted-pre-onboarding-budget-management/assets/102012155/3a1fb203-14ca-4235-adf7-4d532cc7b028">
