### PR TITLE
feat: 예산 수정 기능 추가

### DIFF
--- a/src/main/java/com/wanted/budgetmanagement/api/budget/controller/BudgetController.java
+++ b/src/main/java/com/wanted/budgetmanagement/api/budget/controller/BudgetController.java
@@ -1,6 +1,7 @@
 package com.wanted.budgetmanagement.api.budget.controller;
 
 import com.wanted.budgetmanagement.api.budget.dto.BudgetSettingRequest;
+import com.wanted.budgetmanagement.api.budget.dto.BudgetUpdateRequest;
 import com.wanted.budgetmanagement.api.budget.service.BudgetService;
 import com.wanted.budgetmanagement.domain.user.entity.User;
 import com.wanted.budgetmanagement.global.exception.BaseResponse;
@@ -10,10 +11,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -32,6 +30,17 @@ public class BudgetController {
         budgetService.budgetSetting(request, user);
 
         return ResponseEntity.ok().body(new BaseResponse<>(200, "예산 설정에 성공했습니다."));
+    }
+
+    @Operation(summary = "Budget 수정 API", responses = {
+            @ApiResponse(responseCode = "200")
+    })
+    @Tag(name = "Budgets")
+    @PatchMapping("/{budgetId}")
+    public ResponseEntity budgetUpdate(@PathVariable Long budgetId, @RequestBody BudgetUpdateRequest request, @AuthenticationPrincipal User user) {
+        budgetService.budgetUpdate(budgetId, request, user);
+
+        return ResponseEntity.ok().body(new BaseResponse<>(200, "예산 수정에 성공했습니다."));
     }
 
 }

--- a/src/main/java/com/wanted/budgetmanagement/api/budget/controller/BudgetController.java
+++ b/src/main/java/com/wanted/budgetmanagement/api/budget/controller/BudgetController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -26,7 +27,7 @@ public class BudgetController {
     })
     @Tag(name = "Budgets")
     @PostMapping
-    public ResponseEntity budgetSetting(@RequestBody BudgetSettingRequest request, @AuthenticationPrincipal User user) {
+    public ResponseEntity budgetSetting(@Validated @RequestBody BudgetSettingRequest request, @AuthenticationPrincipal User user) {
         budgetService.budgetSetting(request, user);
 
         return ResponseEntity.ok().body(new BaseResponse<>(200, "예산 설정에 성공했습니다."));
@@ -37,7 +38,7 @@ public class BudgetController {
     })
     @Tag(name = "Budgets")
     @PatchMapping("/{budgetId}")
-    public ResponseEntity budgetUpdate(@PathVariable Long budgetId, @RequestBody BudgetUpdateRequest request, @AuthenticationPrincipal User user) {
+    public ResponseEntity budgetUpdate(@PathVariable Long budgetId, @Validated @RequestBody BudgetUpdateRequest request, @AuthenticationPrincipal User user) {
         budgetService.budgetUpdate(budgetId, request, user);
 
         return ResponseEntity.ok().body(new BaseResponse<>(200, "예산 수정에 성공했습니다."));

--- a/src/main/java/com/wanted/budgetmanagement/api/budget/dto/BudgetSettingRequest.java
+++ b/src/main/java/com/wanted/budgetmanagement/api/budget/dto/BudgetSettingRequest.java
@@ -3,6 +3,7 @@ package com.wanted.budgetmanagement.api.budget.dto;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -17,7 +18,7 @@ import java.util.Date;
 public class BudgetSettingRequest {
 
     @Schema(description = "설정 예산", example = "100000")
-    @NotBlank(message = "예산을 입력해주세요.")
+    @NotNull(message = "예산을 입력해주세요.")
     private int money;
 
     @Schema(description = "예산 카테고리", example = "식비")
@@ -25,7 +26,7 @@ public class BudgetSettingRequest {
     private String categoryName;
 
     @Schema(description = "기간", example = "2023-11")
-    @NotBlank(message = "기간을 설정해주세요.")
+    @NotNull(message = "기간을 설정해주세요.")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM", timezone = "Asia/Seoul")
     private Date period;
 }

--- a/src/main/java/com/wanted/budgetmanagement/api/budget/dto/BudgetUpdateRequest.java
+++ b/src/main/java/com/wanted/budgetmanagement/api/budget/dto/BudgetUpdateRequest.java
@@ -1,0 +1,19 @@
+package com.wanted.budgetmanagement.api.budget.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class BudgetUpdateRequest {
+
+    @Schema(description = "설정 예산", example = "100000")
+    @NotBlank(message = "예산을 입력해주세요.")
+    private int money;
+
+}

--- a/src/main/java/com/wanted/budgetmanagement/api/budget/dto/BudgetUpdateRequest.java
+++ b/src/main/java/com/wanted/budgetmanagement/api/budget/dto/BudgetUpdateRequest.java
@@ -2,6 +2,7 @@ package com.wanted.budgetmanagement.api.budget.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,7 +14,7 @@ import lombok.NoArgsConstructor;
 public class BudgetUpdateRequest {
 
     @Schema(description = "설정 예산", example = "100000")
-    @NotBlank(message = "예산을 입력해주세요.")
+    @NotNull(message = "예산을 입력해주세요.")
     private int money;
 
 }

--- a/src/main/java/com/wanted/budgetmanagement/api/budget/service/BudgetService.java
+++ b/src/main/java/com/wanted/budgetmanagement/api/budget/service/BudgetService.java
@@ -1,6 +1,7 @@
 package com.wanted.budgetmanagement.api.budget.service;
 
 import com.wanted.budgetmanagement.api.budget.dto.BudgetSettingRequest;
+import com.wanted.budgetmanagement.api.budget.dto.BudgetUpdateRequest;
 import com.wanted.budgetmanagement.domain.budget.entity.Budget;
 import com.wanted.budgetmanagement.domain.budget.repository.BudgetRepository;
 import com.wanted.budgetmanagement.domain.budgetCategory.entity.BudgetCategory;
@@ -13,8 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
-import static com.wanted.budgetmanagement.global.exception.BaseExceptionStatus.DUPLICATE_BUDGET;
-import static com.wanted.budgetmanagement.global.exception.BaseExceptionStatus.NON_EXISTENT_CATEGORY;
+import static com.wanted.budgetmanagement.global.exception.BaseExceptionStatus.*;
 
 @Service
 @RequiredArgsConstructor
@@ -57,5 +57,22 @@ public class BudgetService {
         if (exists != null) {
             throw new BaseException(DUPLICATE_BUDGET);
         }
+    }
+
+    /**
+     * 예산 수정
+     * budgetId, money, user를 받아서 예산을 수정한다.
+     * 만약 없는 budgetId가 들어오면 예외 발생, 수정할 예산의 유저와 다를경우 예외 발생
+     * @param budgetId
+     * @param request : money
+     * @param user
+     */
+    @Transactional
+    public void budgetUpdate(Long budgetId, BudgetUpdateRequest request, User user) {
+        Budget budget = budgetRepository.findById(budgetId).orElseThrow(() -> new BaseException(NON_EXISTENT_BUDGET));
+        if (budget.getUser().getId() != user.getId()) {
+            throw new BaseException(FORBIDDEN_USER);
+        }
+        budget.updateBudget(request.getMoney());
     }
 }

--- a/src/main/java/com/wanted/budgetmanagement/domain/budget/entity/Budget.java
+++ b/src/main/java/com/wanted/budgetmanagement/domain/budget/entity/Budget.java
@@ -38,4 +38,8 @@ public class Budget {
 
     @Temporal(TemporalType.DATE)
     private Date period;
+
+    public void updateBudget(long money) {
+        this.money = money;
+    }
 }

--- a/src/main/java/com/wanted/budgetmanagement/global/exception/BaseExceptionStatus.java
+++ b/src/main/java/com/wanted/budgetmanagement/global/exception/BaseExceptionStatus.java
@@ -12,7 +12,9 @@ public enum BaseExceptionStatus {
     NON_EXISTENT_USER(HttpStatus.BAD_REQUEST, "존재하지 않는 유저입니다."),
     LOGIN_USER_NOT_EXIST(HttpStatus.BAD_REQUEST, "아이디 또는 비밀번호가 일치하지 않습니다."),
     NON_EXISTENT_CATEGORY(HttpStatus.BAD_REQUEST, "존재하지 않는 카테고리입니다."),
-    DUPLICATE_BUDGET(HttpStatus.CONFLICT, "이미 설정한 예산입니다.");
+    DUPLICATE_BUDGET(HttpStatus.CONFLICT, "이미 설정한 예산입니다."),
+    NON_EXISTENT_BUDGET(HttpStatus.BAD_REQUEST, "존재하지 않는 예산입니다."),
+    FORBIDDEN_USER(HttpStatus.FORBIDDEN, "권한이 없는 유저입니다.");
 
     private final HttpStatus code;
     private final String message;

--- a/src/test/java/com/wanted/budgetmanagement/api/budget/service/BudgetServiceTest.java
+++ b/src/test/java/com/wanted/budgetmanagement/api/budget/service/BudgetServiceTest.java
@@ -1,6 +1,8 @@
 package com.wanted.budgetmanagement.api.budget.service;
 
 import com.wanted.budgetmanagement.api.budget.dto.BudgetSettingRequest;
+import com.wanted.budgetmanagement.api.budget.dto.BudgetUpdateRequest;
+import com.wanted.budgetmanagement.domain.budget.entity.Budget;
 import com.wanted.budgetmanagement.domain.budget.repository.BudgetRepository;
 import com.wanted.budgetmanagement.domain.budgetCategory.entity.BudgetCategory;
 import com.wanted.budgetmanagement.domain.budgetCategory.repository.BudgetCategoryRepository;
@@ -17,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Date;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
@@ -61,6 +64,60 @@ class BudgetServiceTest {
         // then
         assertThatThrownBy(() -> budgetService.budgetSetting(request, user)).hasMessage("존재하지 않는 카테고리입니다.");
 
+    }
+
+    @DisplayName("예산 수정 성공")
+    @Test
+    void budgetUpdate() {
+        // given
+        User user = new User(1L, "email@gmail.com", "password", null);
+        BudgetCategory category = new BudgetCategory(1L, "식비");
+        Budget budget = new Budget(1L, user, category, 10000, new Date(202311));
+
+        BudgetUpdateRequest request = new BudgetUpdateRequest(1000002);
+
+        // stub
+        when(budgetRepository.findById(budget.getId())).thenReturn(Optional.of(budget));
+
+        // when
+        budgetService.budgetUpdate(budget.getId(), request, user);
+
+        // then
+        assertThat(budget.getMoney()).isEqualTo(request.getMoney());
+    }
+
+    @DisplayName("존재하지 않는 예산으로 인한 수정 실패")
+    @Test
+    void budgetUpdateFail() {
+        // given
+        User user = new User(1L, "email@gmail.com", "password", null);
+        BudgetCategory category = new BudgetCategory(1L, "식비");
+        Budget budget = new Budget(1L, user, category, 10000, new Date(202311));
+
+        BudgetUpdateRequest request = new BudgetUpdateRequest(1000002);
+
+        // stub
+        // when
+        // then
+        assertThatThrownBy(() -> budgetService.budgetUpdate(budget.getId(), request, user)).hasMessage("존재하지 않는 예산입니다.");
+    }
+
+    @DisplayName("수정할 예산의 유저와 다른 유저로 인한 수정 실패")
+    @Test
+    void budgetUpdateFail2() {
+        // given
+        User user = new User(1L, "email@gmail.com", "password", null);
+        BudgetCategory category = new BudgetCategory(1L, "식비");
+        Budget budget = new Budget(1L, user, category, 10000, new Date(202311));
+        User failUser = new User(2L, "email2@gmail.com", "password", null);
+        BudgetUpdateRequest request = new BudgetUpdateRequest(1000002);
+
+        // stub
+        when(budgetRepository.findById(budget.getId())).thenReturn(Optional.of(budget));
+
+        // when
+        // then
+        assertThatThrownBy(() -> budgetService.budgetUpdate(budget.getId(), request, failUser)).hasMessage("권한이 없는 유저입니다.");
     }
 
 }


### PR DESCRIPTION
## 작업 내용
- 예산 수정 기능 추가, 예산 수정 테스트 코드 추가, @Validated 추가

<br><br>

## 작업 설명
- [`201dd6f`](https://github.com/ks12b0000/wanted-pre-onboarding-budget-management/pull/20/commits/201dd6f8256ffbce91c1ece08f3a62e53aea5478): BudgetUpdateRequest에 money와 budgetId, user로 예산을 수정한다. 만약 없는 budgetId가 들어오면 NON_EXISTENT_BUDGET(존재하지 않는 예산입니다.) 예외 발생, 수정할 예산의 유저와 다를경우 FORBIDDEN_USER(권한이 없는 유저입니다.) 예외 발생
- [`d9c81fb`](https://github.com/ks12b0000/wanted-pre-onboarding-budget-management/pull/20/commits/d9c81fbecdfd3cd43fb4c557df08acf2fd007596): BudgetServiceTest에 예산 수정 성공, 실패 테스트 코드 추가
- [`a186ba7`](https://github.com/ks12b0000/wanted-pre-onboarding-budget-management/pull/20/commits/a186ba78e566e04407926f03b69463735b97e9f5): @Validated 추가 및 requestDto 설정 수정
<br><br>

## 테스트
- 예산 수정 성공
<img width="1385" alt="스크린샷 2023-11-12 오후 8 09 07" src="https://github.com/ks12b0000/wanted-pre-onboarding-budget-management/assets/102012155/f06985c8-338e-42d4-8644-fe492544dc78">

- 예산 수정 실패
<img width="1383" alt="스크린샷 2023-11-12 오후 8 09 36" src="https://github.com/ks12b0000/wanted-pre-onboarding-budget-management/assets/102012155/f53334a2-c8f9-4aed-929e-d29a72c2e595">

<img width="1385" alt="스크린샷 2023-11-12 오후 8 10 07" src="https://github.com/ks12b0000/wanted-pre-onboarding-budget-management/assets/102012155/d8ae463a-fcc7-4e7d-8eb0-48ac7993f506">

<img width="353" alt="스크린샷 2023-11-12 오후 8 10 54" src="https://github.com/ks12b0000/wanted-pre-onboarding-budget-management/assets/102012155/22a5394e-1d5b-40c5-b1af-4b304931786a">

