### PR TITLE
feat: 예산 추천 기능 추가

### DIFF
--- a/src/main/java/com/wanted/budgetmanagement/api/budget/controller/BudgetController.java
+++ b/src/main/java/com/wanted/budgetmanagement/api/budget/controller/BudgetController.java
@@ -1,5 +1,6 @@
 package com.wanted.budgetmanagement.api.budget.controller;
 
+import com.wanted.budgetmanagement.api.budget.dto.BudgetRecommendListResponse;
 import com.wanted.budgetmanagement.api.budget.dto.BudgetSettingRequest;
 import com.wanted.budgetmanagement.api.budget.dto.BudgetUpdateRequest;
 import com.wanted.budgetmanagement.api.budget.service.BudgetService;
@@ -42,6 +43,17 @@ public class BudgetController {
         budgetService.budgetUpdate(budgetId, request, user);
 
         return ResponseEntity.ok().body(new BaseResponse<>(200, "예산 수정에 성공했습니다."));
+    }
+
+    @Operation(summary = "Budget 추천 API", responses = {
+            @ApiResponse(responseCode = "200")
+    })
+    @Tag(name = "Budgets")
+    @GetMapping("/recommend")
+    public ResponseEntity budgetRecommend(@RequestParam long totalAmount) {
+        BudgetRecommendListResponse budgetRecommendListResponse = budgetService.budgetRecommend(totalAmount);
+
+        return ResponseEntity.ok().body(new BaseResponse<>(200, "예산 추천에 성공했습니다.", budgetRecommendListResponse));
     }
 
 }

--- a/src/main/java/com/wanted/budgetmanagement/api/budget/dto/BudgetRecommendListResponse.java
+++ b/src/main/java/com/wanted/budgetmanagement/api/budget/dto/BudgetRecommendListResponse.java
@@ -1,0 +1,15 @@
+package com.wanted.budgetmanagement.api.budget.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BudgetRecommendListResponse {
+
+    List<BudgetRecommendResponse> responseList;
+}

--- a/src/main/java/com/wanted/budgetmanagement/api/budget/dto/BudgetRecommendResponse.java
+++ b/src/main/java/com/wanted/budgetmanagement/api/budget/dto/BudgetRecommendResponse.java
@@ -1,0 +1,16 @@
+package com.wanted.budgetmanagement.api.budget.dto;
+
+import com.wanted.budgetmanagement.domain.budgetCategory.entity.BudgetCategory;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BudgetRecommendResponse {
+
+    private BudgetCategory category;
+
+    private long average;
+}

--- a/src/main/java/com/wanted/budgetmanagement/api/budget/dto/BudgetSettingRequest.java
+++ b/src/main/java/com/wanted/budgetmanagement/api/budget/dto/BudgetSettingRequest.java
@@ -19,7 +19,7 @@ public class BudgetSettingRequest {
 
     @Schema(description = "설정 예산", example = "100000")
     @NotNull(message = "예산을 입력해주세요.")
-    private int money;
+    private long money;
 
     @Schema(description = "예산 카테고리", example = "식비")
     @NotBlank(message = "카테고리를 입력해주세요")

--- a/src/main/java/com/wanted/budgetmanagement/api/budget/dto/BudgetUpdateRequest.java
+++ b/src/main/java/com/wanted/budgetmanagement/api/budget/dto/BudgetUpdateRequest.java
@@ -15,6 +15,6 @@ public class BudgetUpdateRequest {
 
     @Schema(description = "설정 예산", example = "100000")
     @NotNull(message = "예산을 입력해주세요.")
-    private int money;
+    private long money;
 
 }

--- a/src/main/java/com/wanted/budgetmanagement/api/budget/service/BudgetService.java
+++ b/src/main/java/com/wanted/budgetmanagement/api/budget/service/BudgetService.java
@@ -1,5 +1,7 @@
 package com.wanted.budgetmanagement.api.budget.service;
 
+import com.wanted.budgetmanagement.api.budget.dto.BudgetRecommendListResponse;
+import com.wanted.budgetmanagement.api.budget.dto.BudgetRecommendResponse;
 import com.wanted.budgetmanagement.api.budget.dto.BudgetSettingRequest;
 import com.wanted.budgetmanagement.api.budget.dto.BudgetUpdateRequest;
 import com.wanted.budgetmanagement.domain.budget.entity.Budget;
@@ -12,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 import static com.wanted.budgetmanagement.global.exception.BaseExceptionStatus.*;
@@ -74,5 +77,18 @@ public class BudgetService {
             throw new BaseException(FORBIDDEN_USER);
         }
         budget.updateBudget(request.getMoney());
+    }
+
+    /**
+     * 예산 추천
+     * totalAmount를 기존 이용중인 유저들이 설정한 평균값으로 카테고리별로 적정 금액을 나눠서 반환한다.
+     * @param totalAmount
+     * @return
+     */
+    @Transactional(readOnly = true)
+    public BudgetRecommendListResponse budgetRecommend(long totalAmount) {
+        List<BudgetRecommendResponse> responseList = budgetRepository.findByAverage(totalAmount);
+
+        return new BudgetRecommendListResponse(responseList);
     }
 }

--- a/src/main/java/com/wanted/budgetmanagement/domain/budget/repository/BudgetRepository.java
+++ b/src/main/java/com/wanted/budgetmanagement/domain/budget/repository/BudgetRepository.java
@@ -1,12 +1,23 @@
 package com.wanted.budgetmanagement.domain.budget.repository;
 
+import com.wanted.budgetmanagement.api.budget.dto.BudgetRecommendListResponse;
+import com.wanted.budgetmanagement.api.budget.dto.BudgetRecommendResponse;
 import com.wanted.budgetmanagement.domain.budget.entity.Budget;
 import com.wanted.budgetmanagement.domain.budgetCategory.entity.BudgetCategory;
 import com.wanted.budgetmanagement.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Date;
+import java.util.List;
 
 public interface BudgetRepository extends JpaRepository<Budget,Long> {
     Budget findByCategoryAndPeriodAndUser(BudgetCategory category, Date period, User user);
+
+    @Query("select new com.wanted.budgetmanagement.api.budget.dto.BudgetRecommendResponse(" +
+            "category, round(:totalAmount  * ((round(sum(money) * 100 / (select sum(money) from Budget), 0)) / 100), 0) as average) " +
+            "from Budget " +
+            "group by category")
+    List<BudgetRecommendResponse> findByAverage(@Param("totalAmount") long totalAmount);
 }

--- a/src/test/java/com/wanted/budgetmanagement/api/budget/controller/BudgetControllerTest.java
+++ b/src/test/java/com/wanted/budgetmanagement/api/budget/controller/BudgetControllerTest.java
@@ -18,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Date;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -78,6 +79,23 @@ class BudgetControllerTest {
         resultActions.andExpect(status().isBadRequest())
                 .andExpect(jsonPath("code").value("400"))
                 .andExpect(jsonPath("message").value("존재하지 않는 카테고리입니다."));
+
+    }
+
+    @DisplayName("예산 추천 성공")
+    @Test
+    @WithMockUser
+    void budgetRecommend() throws Exception {
+        // given
+        long totalAmount = 1000000L;
+
+        // when
+        ResultActions resultActions = mvc.perform(get("/api/budgets/recommend?totalAmount=" + totalAmount));
+
+        // then
+        resultActions.andExpect(status().isOk())
+                .andExpect(jsonPath("code").value("200"))
+                .andExpect(jsonPath("message").value("예산 추천에 성공했습니다."));
 
     }
 }

--- a/src/test/java/com/wanted/budgetmanagement/api/budget/service/BudgetServiceTest.java
+++ b/src/test/java/com/wanted/budgetmanagement/api/budget/service/BudgetServiceTest.java
@@ -1,5 +1,7 @@
 package com.wanted.budgetmanagement.api.budget.service;
 
+import com.wanted.budgetmanagement.api.budget.dto.BudgetRecommendListResponse;
+import com.wanted.budgetmanagement.api.budget.dto.BudgetRecommendResponse;
 import com.wanted.budgetmanagement.api.budget.dto.BudgetSettingRequest;
 import com.wanted.budgetmanagement.api.budget.dto.BudgetUpdateRequest;
 import com.wanted.budgetmanagement.domain.budget.entity.Budget;
@@ -16,7 +18,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -118,6 +122,26 @@ class BudgetServiceTest {
         // when
         // then
         assertThatThrownBy(() -> budgetService.budgetUpdate(budget.getId(), request, failUser)).hasMessage("권한이 없는 유저입니다.");
+    }
+
+    @DisplayName("예산 추천 성공")
+    @Test
+    void budgetRecommend() {
+        // given
+        BudgetCategory category = new BudgetCategory(1L, "식비");
+        BudgetRecommendResponse recommendResponse = new BudgetRecommendResponse(category, 1000000L);
+        long totalAmount = 1000000L;
+        List<BudgetRecommendResponse> list = new ArrayList<>();
+        list.add(recommendResponse);
+
+        // stub
+        when(budgetRepository.findByAverage(totalAmount)).thenReturn(list);
+
+        // when
+        BudgetRecommendListResponse response = budgetService.budgetRecommend(totalAmount);
+
+        // then
+        assertThat(response.getResponseList().get(0).getAverage()).isEqualTo(1000000L);
     }
 
 }

--- a/src/test/java/com/wanted/budgetmanagement/domain/budget/repository/BudgetRepositoryTest.java
+++ b/src/test/java/com/wanted/budgetmanagement/domain/budget/repository/BudgetRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.wanted.budgetmanagement.domain.budget.repository;
 
+import com.wanted.budgetmanagement.api.budget.dto.BudgetRecommendResponse;
 import com.wanted.budgetmanagement.domain.budget.entity.Budget;
 import com.wanted.budgetmanagement.domain.budgetCategory.entity.BudgetCategory;
 import com.wanted.budgetmanagement.domain.budgetCategory.repository.BudgetCategoryRepository;
@@ -13,6 +14,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.security.test.context.support.WithMockUser;
 
 import java.util.Date;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
@@ -50,4 +52,18 @@ class BudgetRepositoryTest {
                 () -> assertThat(saveBudget.getPeriod()).isEqualTo(budget.getPeriod())
         );
     }
+
+    @DisplayName("예산 추천 쿼리 동작 확인")
+    @Test
+    void budgetRecommend() {
+        // given
+        long totalAmount = 1000000L;
+
+        // when
+        List<BudgetRecommendResponse> responses = budgetRepository.findByAverage(totalAmount);
+
+        // then
+        assertThat(responses).isNotNull();
+    }
+
 }


### PR DESCRIPTION
## 작업 내용
- 예산 추천 기능 추가, 예산 추천 테스트 코드 추가, money를 int -> long으로 변경
<br><br>

## 작업 설명
- [`9681365`](https://github.com/ks12b0000/wanted-pre-onboarding-budget-management/pull/21/commits/9681365c70c49117dbab480b1cfe5ecd2f122a4e):유저들이 설정한 카테고리 별 평균 예산을 통계하여  totalAmount에 값을 카테고리 별 평균 예산에 맞게 나눠서 반환한다.
- [`e7ca377`](https://github.com/ks12b0000/wanted-pre-onboarding-budget-management/pull/21/commits/e7ca377c28d3eb6c61f66454905144941d5ee997): 예산 설정, 수정에 money를 int -> long으로 변경
- [`b760d80`](https://github.com/ks12b0000/wanted-pre-onboarding-budget-management/pull/21/commits/b760d805ee06f361054ab1e557449221d96f5132): BudgetRepositoryTest, BudgetServiceTest, BudgetControllerTest에 예산 추천 성공 테스트 코드 추가
<br><br>

## 테스트
- 예산 추천 성공
<img width="1391" alt="스크린샷 2023-11-13 오전 11 11 38" src="https://github.com/ks12b0000/wanted-pre-onboarding-budget-management/assets/102012155/77afe758-fd33-452d-9360-d892491affa9">

<img width="353" alt="스크린샷 2023-11-13 오전 11 12 45" src="https://github.com/ks12b0000/wanted-pre-onboarding-budget-management/assets/102012155/21d4e2f6-3b98-45f3-b00d-e756244d08d8">

