### PR TITLE
feat: 지출 수정 기능 추가

### DIFF
--- a/src/main/java/com/wanted/budgetmanagement/api/Expenditure/controller/ExpenditureController.java
+++ b/src/main/java/com/wanted/budgetmanagement/api/Expenditure/controller/ExpenditureController.java
@@ -1,6 +1,7 @@
 package com.wanted.budgetmanagement.api.Expenditure.controller;
 
 import com.wanted.budgetmanagement.api.Expenditure.dto.ExpenditureCreateRequest;
+import com.wanted.budgetmanagement.api.Expenditure.dto.ExpenditureUpdateRequest;
 import com.wanted.budgetmanagement.api.Expenditure.service.ExpenditureService;
 import com.wanted.budgetmanagement.domain.user.entity.User;
 import com.wanted.budgetmanagement.global.exception.BaseResponse;
@@ -11,10 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 
@@ -35,5 +33,16 @@ public class ExpenditureController {
         expenditureService.expenditureCreate(request, user);
 
         return ResponseEntity.created(URI.create("/api/expenditures")).body(new BaseResponse<>(201, "지출 생성에 성공했습니다."));
+    }
+
+    @Operation(summary = "Expenditures 수정 API", responses = {
+            @ApiResponse(responseCode = "200")
+    })
+    @Tag(name = "Expenditures")
+    @PatchMapping("/{expenditureId}")
+    public ResponseEntity budgetUpdate(@PathVariable Long expenditureId, @Validated @RequestBody ExpenditureUpdateRequest request, @AuthenticationPrincipal User user) {
+        expenditureService.expenditureUpdate(expenditureId, request, user);
+
+        return ResponseEntity.ok().body(new BaseResponse<>(200, "지출 수정에 성공했습니다."));
     }
 }

--- a/src/main/java/com/wanted/budgetmanagement/api/Expenditure/dto/ExpenditureUpdateRequest.java
+++ b/src/main/java/com/wanted/budgetmanagement/api/Expenditure/dto/ExpenditureUpdateRequest.java
@@ -1,0 +1,31 @@
+package com.wanted.budgetmanagement.api.Expenditure.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ExpenditureUpdateRequest {
+
+    @Schema(description = "지출 금액", example = "20000")
+    @NotNull(message = "지출 금액을 입력해주세요.")
+    private long money;
+
+    @Schema(description = "지출 카테고리", example = "식비")
+    @NotBlank(message = "카테고리를 입력해주세요")
+    private String categoryName;
+
+    @Schema(description = "지출 일시", example = "2023-11-13")
+    @NotNull(message = "지출 일시를 설정해주세요.")
+    private LocalDate period;
+
+    @Schema(description = "메모", example = "저녁값으로 지출")
+    private String memo;
+}

--- a/src/main/java/com/wanted/budgetmanagement/domain/expenditure/entity/Expenditure.java
+++ b/src/main/java/com/wanted/budgetmanagement/domain/expenditure/entity/Expenditure.java
@@ -1,5 +1,6 @@
 package com.wanted.budgetmanagement.domain.expenditure.entity;
 
+import com.wanted.budgetmanagement.api.Expenditure.dto.ExpenditureUpdateRequest;
 import com.wanted.budgetmanagement.domain.budgetCategory.entity.BudgetCategory;
 import com.wanted.budgetmanagement.domain.user.entity.User;
 import jakarta.persistence.*;
@@ -44,4 +45,11 @@ public class Expenditure {
 
     @Column
     private long money;
+
+    public void updateExpenditure(ExpenditureUpdateRequest request, BudgetCategory category) {
+        this.money = request.getMoney();
+        this.category = category;
+        this.period = request.getPeriod();
+        this.memo = request.getMemo();
+    }
 }

--- a/src/main/java/com/wanted/budgetmanagement/global/exception/BaseExceptionStatus.java
+++ b/src/main/java/com/wanted/budgetmanagement/global/exception/BaseExceptionStatus.java
@@ -14,7 +14,8 @@ public enum BaseExceptionStatus {
     NON_EXISTENT_CATEGORY(HttpStatus.BAD_REQUEST, "존재하지 않는 카테고리입니다."),
     DUPLICATE_BUDGET(HttpStatus.CONFLICT, "이미 설정한 예산입니다."),
     NON_EXISTENT_BUDGET(HttpStatus.BAD_REQUEST, "존재하지 않는 예산입니다."),
-    FORBIDDEN_USER(HttpStatus.FORBIDDEN, "권한이 없는 유저입니다.");
+    FORBIDDEN_USER(HttpStatus.FORBIDDEN, "권한이 없는 유저입니다."),
+    NON_EXISTENT_EXPENDITURE(HttpStatus.BAD_REQUEST, "존재하지 않는 지출입니다.");
 
     private final HttpStatus code;
     private final String message;


### PR DESCRIPTION
## 작업 내용
- 지출 수정 기능 추가, 지출 수정 테스트 코드 추가
<br><br>

## 작업 설명
- [`ab11be6`](https://github.com/ks12b0000/wanted-pre-onboarding-budget-management/pull/23/commits/ab11be6b73050ee09ba569c89c6566bedeb34f69): ExpenditureUpdateRequest에 money, memo, category, period와 expenditureId, user로 지출을 수정한다.  만약 존재하지 않는 expenditureId가 들어오면 NON_EXISTENT_EXPENDITURE(존재하지 않는 지출입니다.) 예외 발생, 존재하지 않는 category가 들어오면 NON_EXISTENT_CATEGORY(존재하지 않는 카테고리입니다.) 예외 발생, 수정할 지출의 유저와 다를경우 FORBIDDEN_USER(권한이 없는 유저입니다.) 예외 발생
- [`ed54695`](https://github.com/ks12b0000/wanted-pre-onboarding-budget-management/pull/23/commits/ed5469569e8275b76cc24df84d9d4c7ee354be54): ExpenditureServiceTest에 지출 수정 성공, 실패 테스트 코드  추가.
<br><br>

## 테스트
- 지출 수정 성공
<img width="1386" alt="스크린샷 2023-11-13 오후 4 58 30" src="https://github.com/ks12b0000/wanted-pre-onboarding-budget-management/assets/102012155/7e7022dd-b2bd-4480-a35c-34483c0b0ccc">

- 지출 수정 실패
<img width="1387" alt="스크린샷 2023-11-13 오후 4 59 12" src="https://github.com/ks12b0000/wanted-pre-onboarding-budget-management/assets/102012155/95ca45ad-d359-4c19-8184-2d85b3ffa1ea">
<img width="1382" alt="스크린샷 2023-11-13 오후 4 59 36" src="https://github.com/ks12b0000/wanted-pre-onboarding-budget-management/assets/102012155/8096604a-e94b-4956-8053-36b3b566c7b2">
<img width="1389" alt="스크린샷 2023-11-13 오후 5 00 21" src="https://github.com/ks12b0000/wanted-pre-onboarding-budget-management/assets/102012155/41653e4d-1e50-4348-bd4c-f71231245510">
<img width="376" alt="스크린샷 2023-11-13 오후 5 01 00" src="https://github.com/ks12b0000/wanted-pre-onboarding-budget-management/assets/102012155/5e2702cc-e01f-42d1-a6b1-3c22761e234b">

