### PR TITLE
feat: 지출 목록 조회 기능 추가

### DIFF
--- a/src/main/java/com/wanted/budgetmanagement/api/expenditure/controller/ExpenditureController.java
+++ b/src/main/java/com/wanted/budgetmanagement/api/expenditure/controller/ExpenditureController.java
@@ -1,8 +1,9 @@
-package com.wanted.budgetmanagement.api.Expenditure.controller;
+package com.wanted.budgetmanagement.api.expenditure.controller;
 
-import com.wanted.budgetmanagement.api.Expenditure.dto.ExpenditureCreateRequest;
-import com.wanted.budgetmanagement.api.Expenditure.dto.ExpenditureUpdateRequest;
-import com.wanted.budgetmanagement.api.Expenditure.service.ExpenditureService;
+import com.wanted.budgetmanagement.api.expenditure.dto.ExpenditureCreateRequest;
+import com.wanted.budgetmanagement.api.expenditure.dto.ExpenditureListResponse;
+import com.wanted.budgetmanagement.api.expenditure.dto.ExpenditureUpdateRequest;
+import com.wanted.budgetmanagement.api.expenditure.service.ExpenditureService;
 import com.wanted.budgetmanagement.domain.user.entity.User;
 import com.wanted.budgetmanagement.global.exception.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -15,6 +16,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
+import java.time.LocalDate;
 
 @RestController
 @RequiredArgsConstructor
@@ -40,9 +42,22 @@ public class ExpenditureController {
     })
     @Tag(name = "Expenditures")
     @PatchMapping("/{expenditureId}")
-    public ResponseEntity budgetUpdate(@PathVariable Long expenditureId, @Validated @RequestBody ExpenditureUpdateRequest request, @AuthenticationPrincipal User user) {
+    public ResponseEntity expenditureUpdate(@PathVariable Long expenditureId, @Validated @RequestBody ExpenditureUpdateRequest request, @AuthenticationPrincipal User user) {
         expenditureService.expenditureUpdate(expenditureId, request, user);
 
         return ResponseEntity.ok().body(new BaseResponse<>(200, "지출 수정에 성공했습니다."));
+    }
+
+    @Operation(summary = "Expenditures 목록 조회 API", responses = {
+            @ApiResponse(responseCode = "200")
+    })
+    @Tag(name = "Expenditures")
+    @GetMapping
+    public ResponseEntity expenditureList(@RequestParam LocalDate minPeriod, @RequestParam LocalDate maxPeriod,
+                                       @RequestParam String categoryName, @RequestParam long minMoney,
+                                       @RequestParam long maxMoney, @AuthenticationPrincipal User user) {
+        ExpenditureListResponse listResponse = expenditureService.expenditureList(minPeriod, maxPeriod, categoryName, minMoney, maxMoney, user);
+
+        return ResponseEntity.ok().body(new BaseResponse<>(200, "지출 목록 조회에 성공했습니다.", listResponse));
     }
 }

--- a/src/main/java/com/wanted/budgetmanagement/api/expenditure/dto/ExpenditureCreateRequest.java
+++ b/src/main/java/com/wanted/budgetmanagement/api/expenditure/dto/ExpenditureCreateRequest.java
@@ -1,4 +1,4 @@
-package com.wanted.budgetmanagement.api.Expenditure.dto;
+package com.wanted.budgetmanagement.api.expenditure.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
@@ -8,7 +8,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
-import java.util.Date;
 
 @Getter
 @AllArgsConstructor

--- a/src/main/java/com/wanted/budgetmanagement/api/expenditure/dto/ExpenditureList.java
+++ b/src/main/java/com/wanted/budgetmanagement/api/expenditure/dto/ExpenditureList.java
@@ -1,0 +1,26 @@
+package com.wanted.budgetmanagement.api.expenditure.dto;
+
+import com.wanted.budgetmanagement.domain.budgetCategory.entity.BudgetCategory;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExpenditureList {
+
+    private String memo;
+
+    private LocalDate period;
+
+    private BudgetCategory category;
+
+    private boolean excludingTotal;
+
+    private long money;
+
+
+}

--- a/src/main/java/com/wanted/budgetmanagement/api/expenditure/dto/ExpenditureListResponse.java
+++ b/src/main/java/com/wanted/budgetmanagement/api/expenditure/dto/ExpenditureListResponse.java
@@ -1,0 +1,19 @@
+package com.wanted.budgetmanagement.api.expenditure.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExpenditureListResponse {
+
+    private List<ExpenditureList> expenditureLists;
+
+    private long viewMoneyTotal;
+
+    private long totalCategoryMoneyTotal;
+}

--- a/src/main/java/com/wanted/budgetmanagement/api/expenditure/dto/ExpenditureUpdateRequest.java
+++ b/src/main/java/com/wanted/budgetmanagement/api/expenditure/dto/ExpenditureUpdateRequest.java
@@ -1,4 +1,4 @@
-package com.wanted.budgetmanagement.api.Expenditure.dto;
+package com.wanted.budgetmanagement.api.expenditure.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;

--- a/src/main/java/com/wanted/budgetmanagement/api/expenditure/service/ExpenditureService.java
+++ b/src/main/java/com/wanted/budgetmanagement/api/expenditure/service/ExpenditureService.java
@@ -1,7 +1,9 @@
-package com.wanted.budgetmanagement.api.Expenditure.service;
+package com.wanted.budgetmanagement.api.expenditure.service;
 
-import com.wanted.budgetmanagement.api.Expenditure.dto.ExpenditureCreateRequest;
-import com.wanted.budgetmanagement.api.Expenditure.dto.ExpenditureUpdateRequest;
+import com.wanted.budgetmanagement.api.expenditure.dto.ExpenditureCreateRequest;
+import com.wanted.budgetmanagement.api.expenditure.dto.ExpenditureList;
+import com.wanted.budgetmanagement.api.expenditure.dto.ExpenditureListResponse;
+import com.wanted.budgetmanagement.api.expenditure.dto.ExpenditureUpdateRequest;
 import com.wanted.budgetmanagement.domain.budget.entity.Budget;
 import com.wanted.budgetmanagement.domain.budget.repository.BudgetRepository;
 import com.wanted.budgetmanagement.domain.budgetCategory.entity.BudgetCategory;
@@ -15,6 +17,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.List;
 
 import static com.wanted.budgetmanagement.global.exception.BaseExceptionStatus.*;
 
@@ -77,5 +80,29 @@ public class ExpenditureService {
             throw new BaseException(FORBIDDEN_USER);
         }
         expenditure.updateExpenditure(request, category);
+    }
+
+    /**
+     * 지출 목록 조회
+     * 기간, 카테고리, 최소, 최대 금액으로 지출 목록을 조회한다.
+     * 조회된 모든 내용의 지출 합계, 카테고리별 지출 합계를 같이 반환합니다.
+     * request에서 받은 categoryName으로 카테고리를 조회 후 존재하지 않은 카테고리면 예외 발생
+     * @param minPeriod
+     * @param maxPeriod
+     * @param categoryName
+     * @param minMoney
+     * @param maxMoney
+     * @param user
+     * @return
+     */
+    @Transactional(readOnly = true)
+    public ExpenditureListResponse expenditureList(LocalDate minPeriod, LocalDate maxPeriod,
+                                String categoryName, long minMoney, long maxMoney, User user) {
+        BudgetCategory category = categoryRepository.findByName(categoryName).orElseThrow(() -> new BaseException(NON_EXISTENT_CATEGORY));
+        List<ExpenditureList> expenditureList = expenditureRepository.findByExpenditureList(minPeriod, maxPeriod, category, user, minMoney, maxMoney);
+        long viewMoneyTotal = expenditureRepository.findByViewMoneyTotal(minPeriod, maxPeriod, category, user, minMoney, maxMoney);
+        long totalCategoryMoneyTotal = expenditureRepository.findByTotalCategoryMoneyTotal(category, user);
+
+        return new ExpenditureListResponse(expenditureList, viewMoneyTotal, totalCategoryMoneyTotal);
     }
 }

--- a/src/main/java/com/wanted/budgetmanagement/domain/expenditure/entity/Expenditure.java
+++ b/src/main/java/com/wanted/budgetmanagement/domain/expenditure/entity/Expenditure.java
@@ -1,6 +1,6 @@
 package com.wanted.budgetmanagement.domain.expenditure.entity;
 
-import com.wanted.budgetmanagement.api.Expenditure.dto.ExpenditureUpdateRequest;
+import com.wanted.budgetmanagement.api.expenditure.dto.ExpenditureUpdateRequest;
 import com.wanted.budgetmanagement.domain.budgetCategory.entity.BudgetCategory;
 import com.wanted.budgetmanagement.domain.user.entity.User;
 import jakarta.persistence.*;
@@ -12,7 +12,6 @@ import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 
 import java.time.LocalDate;
-import java.util.Date;
 
 @Entity
 @Getter

--- a/src/main/java/com/wanted/budgetmanagement/domain/expenditure/repository/ExpenditureRepository.java
+++ b/src/main/java/com/wanted/budgetmanagement/domain/expenditure/repository/ExpenditureRepository.java
@@ -1,8 +1,37 @@
 package com.wanted.budgetmanagement.domain.expenditure.repository;
 
+import com.wanted.budgetmanagement.api.expenditure.dto.ExpenditureList;
+import com.wanted.budgetmanagement.domain.budgetCategory.entity.BudgetCategory;
 import com.wanted.budgetmanagement.domain.expenditure.entity.Expenditure;
 import com.wanted.budgetmanagement.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
 
 public interface ExpenditureRepository extends JpaRepository<Expenditure,Long> {
+
+    @Query("select new com.wanted.budgetmanagement.api.expenditure.dto.ExpenditureList(" +
+            "memo, period, category, excludingTotal, money) " +
+            "from Expenditure " +
+            "where category = :category AND period BETWEEN :minPeriod AND :maxPeriod " +
+            "AND user = :user AND money >= :minMoney AND money <= :maxMoney")
+    List<ExpenditureList> findByExpenditureList(@Param("minPeriod") LocalDate minPeriod, @Param("maxPeriod") LocalDate maxPeriod,
+                                                @Param("category") BudgetCategory category, @Param("user") User user,
+                                                @Param("minMoney") long minMoney, @Param("maxMoney") long maxMoney);
+
+    @Query("select sum(money) " +
+            "from Expenditure " +
+            "where category = :category AND period BETWEEN :minPeriod AND :maxPeriod " +
+            "AND user = :user AND money >= :minMoney AND money <= :maxMoney AND excludingTotal = false")
+    long findByViewMoneyTotal(@Param("minPeriod") LocalDate minPeriod, @Param("maxPeriod") LocalDate maxPeriod,
+                              @Param("category") BudgetCategory category, @Param("user") User user,
+                              @Param("minMoney") long minMoney, @Param("maxMoney") long maxMoney);
+
+    @Query("select sum(money) " +
+            "from Expenditure " +
+            "where category = :category AND user = :user AND excludingTotal = false")
+    long findByTotalCategoryMoneyTotal(@Param("category") BudgetCategory category, @Param("user") User user);
 }

--- a/src/test/java/com/wanted/budgetmanagement/api/expenditure/controller/ExpenditureControllerTest.java
+++ b/src/test/java/com/wanted/budgetmanagement/api/expenditure/controller/ExpenditureControllerTest.java
@@ -1,8 +1,8 @@
-package com.wanted.budgetmanagement.api.Expenditure.controller;
+package com.wanted.budgetmanagement.api.expenditure.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.wanted.budgetmanagement.api.Expenditure.dto.ExpenditureCreateRequest;
+import com.wanted.budgetmanagement.api.expenditure.dto.ExpenditureCreateRequest;
 import com.wanted.budgetmanagement.domain.budgetCategory.entity.BudgetCategory;
 import com.wanted.budgetmanagement.domain.budgetCategory.repository.BudgetCategoryRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -18,7 +18,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;

--- a/src/test/java/com/wanted/budgetmanagement/api/expenditure/service/ExpenditureServiceTest.java
+++ b/src/test/java/com/wanted/budgetmanagement/api/expenditure/service/ExpenditureServiceTest.java
@@ -1,6 +1,7 @@
 package com.wanted.budgetmanagement.api.expenditure.service;
 
 import com.wanted.budgetmanagement.api.expenditure.dto.ExpenditureCreateRequest;
+import com.wanted.budgetmanagement.api.expenditure.dto.ExpenditureListResponse;
 import com.wanted.budgetmanagement.api.expenditure.dto.ExpenditureUpdateRequest;
 import com.wanted.budgetmanagement.domain.budget.entity.Budget;
 import com.wanted.budgetmanagement.domain.budget.repository.BudgetRepository;
@@ -151,5 +152,49 @@ class ExpenditureServiceTest {
         // when
         // then
         assertThatThrownBy(() -> expenditureService.expenditureUpdate(expenditure.getId(), request, failUser)).hasMessage("권한이 없는 유저입니다.");
+    }
+
+    @DisplayName("지출 목록 조회 성공")
+    @Test
+    void expenditureList() {
+        // given
+        LocalDate minPeriod = LocalDate.parse("2023-11-11");
+        LocalDate maxPeriod = LocalDate.parse("2023-11-23");
+        BudgetCategory category = new BudgetCategory(1L, "식비");
+        String categoryName = "식비";
+        long minMoney = 10000L;
+        long maxMoney = 20000L;
+        User user = new User(1L, "email@gmail.com", "password", null);
+
+        // stub
+        when(categoryRepository.findByName(categoryName)).thenReturn(Optional.of(category));
+
+        // when
+        ExpenditureListResponse listResponse = expenditureService.expenditureList(minPeriod, maxPeriod, categoryName, minMoney, maxMoney, user);
+
+        // then
+        assertAll(
+                () -> assertThat(listResponse.getExpenditureLists()).isNotNull(),
+                () -> assertThat(listResponse.getViewMoneyTotal()).isNotNull(),
+                () -> assertThat(listResponse.getTotalCategoryMoneyTotal()).isNotNull()
+        );
+    }
+
+    @DisplayName("지출 목록 조회 실패")
+    @Test
+    void expenditureListFail() {
+        // given
+        LocalDate minPeriod = LocalDate.parse("2023-11-11");
+        LocalDate maxPeriod = LocalDate.parse("2023-11-23");
+        BudgetCategory category = new BudgetCategory(1L, "식비");
+        String categoryName = "식비";
+        long minMoney = 10000L;
+        long maxMoney = 20000L;
+        User user = new User(1L, "email@gmail.com", "password", null);
+
+        // stub
+        // when
+        // then
+        assertThatThrownBy(() -> expenditureService.expenditureList(minPeriod, maxPeriod, categoryName, minMoney, maxMoney, user)).hasMessage("존재하지 않는 카테고리입니다.");
     }
 }

--- a/src/test/java/com/wanted/budgetmanagement/api/expenditure/service/ExpenditureServiceTest.java
+++ b/src/test/java/com/wanted/budgetmanagement/api/expenditure/service/ExpenditureServiceTest.java
@@ -1,7 +1,7 @@
-package com.wanted.budgetmanagement.api.Expenditure.service;
+package com.wanted.budgetmanagement.api.expenditure.service;
 
-import com.wanted.budgetmanagement.api.Expenditure.dto.ExpenditureCreateRequest;
-import com.wanted.budgetmanagement.api.Expenditure.dto.ExpenditureUpdateRequest;
+import com.wanted.budgetmanagement.api.expenditure.dto.ExpenditureCreateRequest;
+import com.wanted.budgetmanagement.api.expenditure.dto.ExpenditureUpdateRequest;
 import com.wanted.budgetmanagement.domain.budget.entity.Budget;
 import com.wanted.budgetmanagement.domain.budget.repository.BudgetRepository;
 import com.wanted.budgetmanagement.domain.budgetCategory.entity.BudgetCategory;
@@ -9,7 +9,6 @@ import com.wanted.budgetmanagement.domain.budgetCategory.repository.BudgetCatego
 import com.wanted.budgetmanagement.domain.expenditure.entity.Expenditure;
 import com.wanted.budgetmanagement.domain.expenditure.repository.ExpenditureRepository;
 import com.wanted.budgetmanagement.domain.user.entity.User;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -19,7 +18,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.util.Date;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;


### PR DESCRIPTION
## 작업 내용
- 지출 목록 조회 기능 추가, 지출 목록 조회 테스트 코드 추가, 지출 패키지 이름 변경

<br><br>

## 작업 설명
- [`bbbbecb`](https://github.com/ks12b0000/wanted-pre-onboarding-budget-management/pull/24/commits/bbbbecba4b733789bcf637a9ceb12f411de930b5): 기간, 카테고리, 최소, 최대 금액으로 지출 목록을 조회한다, 조회된 모든 내용의 지출 합계, 카테고리별 지출 합계를 같이 반환합니다. 만약 존재하지 않는 카테고리가 들어오면 NON_EXISTENT_CATEGORY(존재하지 않는 카테고리입니다.) 예외 발생
- [`50212d8`](https://github.com/ks12b0000/wanted-pre-onboarding-budget-management/pull/24/commits/50212d8530349db9087d015a2071961ec21aa46d): 지출 패키지 이름 Expenditure로 잘못 되어있는 부분 expenditure로 변경
- [`fe29bd4`](https://github.com/ks12b0000/wanted-pre-onboarding-budget-management/pull/24/commits/fe29bd4972d0ca68b1608de3c8db3ca3a03d6fb3): ExpenditureServiceTest에 지출 목록 조회 성공, 실패 테스트 코드 추가

<br><br>

## 테스트
- 지출 목록 조회 성공
<img width="1381" alt="스크린샷 2023-11-13 오후 10 19 38" src="https://github.com/ks12b0000/wanted-pre-onboarding-budget-management/assets/102012155/75048cb7-7af1-4b72-9e09-52bab8d3f3e2">
<img width="1396" alt="스크린샷 2023-11-13 오후 10 20 05" src="https://github.com/ks12b0000/wanted-pre-onboarding-budget-management/assets/102012155/6fc418ce-0bdf-44cf-9cb2-4e941dde1774">

- 지출 목록 조회 실패
<img width="1386" alt="스크린샷 2023-11-13 오후 10 20 56" src="https://github.com/ks12b0000/wanted-pre-onboarding-budget-management/assets/102012155/0193c86a-3e6c-495a-a52d-1516c7335042">
<img width="375" alt="스크린샷 2023-11-13 오후 10 21 29" src="https://github.com/ks12b0000/wanted-pre-onboarding-budget-management/assets/102012155/defe9d91-f519-49e3-956f-601c8b7146f5">

