### PR TITLE
feat: 지출 상세 조회 기능 추가

### DIFF
--- a/src/main/java/com/wanted/budgetmanagement/api/expenditure/controller/ExpenditureController.java
+++ b/src/main/java/com/wanted/budgetmanagement/api/expenditure/controller/ExpenditureController.java
@@ -1,6 +1,7 @@
 package com.wanted.budgetmanagement.api.expenditure.controller;
 
 import com.wanted.budgetmanagement.api.expenditure.dto.ExpenditureCreateRequest;
+import com.wanted.budgetmanagement.api.expenditure.dto.ExpenditureDetailResponse;
 import com.wanted.budgetmanagement.api.expenditure.dto.ExpenditureListResponse;
 import com.wanted.budgetmanagement.api.expenditure.dto.ExpenditureUpdateRequest;
 import com.wanted.budgetmanagement.api.expenditure.service.ExpenditureService;
@@ -59,5 +60,16 @@ public class ExpenditureController {
         ExpenditureListResponse listResponse = expenditureService.expenditureList(minPeriod, maxPeriod, categoryName, minMoney, maxMoney, user);
 
         return ResponseEntity.ok().body(new BaseResponse<>(200, "지출 목록 조회에 성공했습니다.", listResponse));
+    }
+
+    @Operation(summary = "Expenditures 상세 조회 API", responses = {
+            @ApiResponse(responseCode = "200")
+    })
+    @Tag(name = "Expenditures")
+    @GetMapping("/{expenditureId}")
+    public ResponseEntity expenditureDetail(@PathVariable Long expenditureId, @AuthenticationPrincipal User user) {
+        ExpenditureDetailResponse response = expenditureService.expenditureDetail(expenditureId, user);
+
+        return ResponseEntity.ok().body(new BaseResponse<>(200, "지출 상세 조회에 성공했습니다.", response));
     }
 }

--- a/src/main/java/com/wanted/budgetmanagement/api/expenditure/dto/ExpenditureDetailResponse.java
+++ b/src/main/java/com/wanted/budgetmanagement/api/expenditure/dto/ExpenditureDetailResponse.java
@@ -1,0 +1,23 @@
+package com.wanted.budgetmanagement.api.expenditure.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExpenditureDetailResponse {
+
+    private String memo;
+
+    private LocalDate period;
+
+    private String categoryName;
+
+    private boolean excludingTotal;
+
+    private long money;
+}

--- a/src/main/java/com/wanted/budgetmanagement/api/expenditure/service/ExpenditureService.java
+++ b/src/main/java/com/wanted/budgetmanagement/api/expenditure/service/ExpenditureService.java
@@ -107,7 +107,7 @@ public class ExpenditureService {
      * 지출 상세 조회
      * expenditureId로 지출 상세 조회한다.
      * 존재하지 않는 expenditureId가 들어오면 예외 발생,
-     * 수정할 지출의 유저와 다를경우 예외 발생
+     * 조회할 지출의 유저와 다를경우 예외 발생
      * @param expenditureId
      * @param user
      * @return

--- a/src/main/java/com/wanted/budgetmanagement/api/expenditure/service/ExpenditureService.java
+++ b/src/main/java/com/wanted/budgetmanagement/api/expenditure/service/ExpenditureService.java
@@ -1,9 +1,6 @@
 package com.wanted.budgetmanagement.api.expenditure.service;
 
-import com.wanted.budgetmanagement.api.expenditure.dto.ExpenditureCreateRequest;
-import com.wanted.budgetmanagement.api.expenditure.dto.ExpenditureList;
-import com.wanted.budgetmanagement.api.expenditure.dto.ExpenditureListResponse;
-import com.wanted.budgetmanagement.api.expenditure.dto.ExpenditureUpdateRequest;
+import com.wanted.budgetmanagement.api.expenditure.dto.*;
 import com.wanted.budgetmanagement.domain.budget.entity.Budget;
 import com.wanted.budgetmanagement.domain.budget.repository.BudgetRepository;
 import com.wanted.budgetmanagement.domain.budgetCategory.entity.BudgetCategory;
@@ -104,5 +101,25 @@ public class ExpenditureService {
         long totalCategoryMoneyTotal = expenditureRepository.findByTotalCategoryMoneyTotal(category, user);
 
         return new ExpenditureListResponse(expenditureList, viewMoneyTotal, totalCategoryMoneyTotal);
+    }
+
+    /**
+     * 지출 상세 조회
+     * expenditureId로 지출 상세 조회한다.
+     * 존재하지 않는 expenditureId가 들어오면 예외 발생,
+     * 수정할 지출의 유저와 다를경우 예외 발생
+     * @param expenditureId
+     * @param user
+     * @return
+     */
+    @Transactional(readOnly = true)
+    public ExpenditureDetailResponse expenditureDetail(Long expenditureId, User user) {
+        Expenditure expenditure = expenditureRepository.findById(expenditureId).orElseThrow(() -> new BaseException(NON_EXISTENT_EXPENDITURE));
+
+        if (expenditure.getUser().getId() != user.getId()) {
+            throw new BaseException(FORBIDDEN_USER);
+        }
+
+        return new ExpenditureDetailResponse(expenditure.getMemo(), expenditure.getPeriod(), expenditure.getCategory().getName(), expenditure.isExcludingTotal(), expenditure.getMoney());
     }
 }

--- a/src/test/java/com/wanted/budgetmanagement/domain/expenditure/repository/ExpenditureRepositoryTest.java
+++ b/src/test/java/com/wanted/budgetmanagement/domain/expenditure/repository/ExpenditureRepositoryTest.java
@@ -12,6 +12,7 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 import java.time.LocalDate;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
@@ -46,6 +47,32 @@ class ExpenditureRepositoryTest {
                 () -> assertThat(saveExpenditure.getPeriod()).isEqualTo(expenditure.getPeriod()),
                 () -> assertThat(saveExpenditure.getUser().getId()).isEqualTo(expenditure.getUser().getId()),
                 () -> assertThat(saveExpenditure.getMoney()).isEqualTo(expenditure.getMoney())
+
+        );
+
+    }
+
+    @DisplayName("지출 상세 조회")
+    @Test
+    void expenditureDetail() {
+        // given
+        BudgetCategory category = new BudgetCategory(1L, "식비");
+        categoryRepository.save(category);
+        User user = new User(1L, "email@gmail.com", "password", null);
+        LocalDate date = LocalDate.parse("2023-11-11");
+        Expenditure expenditure = new Expenditure(1L, "저녁값 지출", date, category, user, false, 20000L);
+        expenditureRepository.save(expenditure);
+
+        // when
+        Optional<Expenditure> expenditure1 = expenditureRepository.findById(expenditure.getId());
+
+        // then
+        assertAll(
+                () -> assertThat(expenditure1.get().getCategory().getName()).isEqualTo(expenditure.getCategory().getName()),
+                () -> assertThat(expenditure1.get().getMemo()).isEqualTo(expenditure.getMemo()),
+                () -> assertThat(expenditure1.get().getPeriod()).isEqualTo(expenditure.getPeriod()),
+                () -> assertThat(expenditure1.get().getUser().getId()).isEqualTo(expenditure.getUser().getId()),
+                () -> assertThat(expenditure1.get().getMoney()).isEqualTo(expenditure.getMoney())
 
         );
 


### PR DESCRIPTION
## 작업 내용
- 지출 상세 조회 기능 추가, 지출 상세 조회 주석 수정, 지출 상세 조회 테스트 코드 추가
<br><br>

## 작업 설명
- [`bd1d1fc`](https://github.com/ks12b0000/wanted-pre-onboarding-budget-management/pull/26/commits/bd1d1fca288754f5ba0f73ab061d60d65e501490): expenditureId로 지출 상세 조회한다. 존재하지 않는 expenditureId가 들어오면 NON_EXISTENT_EXPENDITURE(존재하지 않는 지출입니다.) 예외 발생, 조회할 지출의 유저와 다를경우 FORBIDDEN_USER(권한이 없는 유저입니다.) 예외 발생
- [`c096173`](https://github.com/ks12b0000/wanted-pre-onboarding-budget-management/pull/26/commits/c0961730471fd6d048b591fc49533b37f14ff7bf): ExpenditureService 주석 수정
- [`9ff3eb4`](https://github.com/ks12b0000/wanted-pre-onboarding-budget-management/pull/26/commits/9ff3eb4cc28efdf1cad251f21f4374b0f83e3dba): ExpenditureServiceTest, ExpenditureRepository에 지출 상세 조회 성공, 실패 테스트 코드 추가
<br><br>

## 테스트
- 지출 상세 조회 성공
<img width="1391" alt="스크린샷 2023-11-13 오후 11 20 06" src="https://github.com/ks12b0000/wanted-pre-onboarding-budget-management/assets/102012155/672fe274-f1a3-431c-a8ee-dd1034298556">

- 지출 상세 조회 실패
<img width="1384" alt="스크린샷 2023-11-13 오후 11 20 55" src="https://github.com/ks12b0000/wanted-pre-onboarding-budget-management/assets/102012155/5f5055da-c459-456d-8c9b-b6ece8885aa9">

<img width="1385" alt="스크린샷 2023-11-13 오후 11 21 25" src="https://github.com/ks12b0000/wanted-pre-onboarding-budget-management/assets/102012155/75a0508a-4751-4113-ae69-ad39c79c2d13">

<img width="377" alt="스크린샷 2023-11-13 오후 11 22 05" src="https://github.com/ks12b0000/wanted-pre-onboarding-budget-management/assets/102012155/93a48b17-9873-4222-8767-b02d44c4c8a6">
