### PR TITLE
feat: 지출 삭제 기능 추가

### DIFF
--- a/src/main/java/com/wanted/budgetmanagement/api/expenditure/controller/ExpenditureController.java
+++ b/src/main/java/com/wanted/budgetmanagement/api/expenditure/controller/ExpenditureController.java
@@ -72,4 +72,15 @@ public class ExpenditureController {
 
         return ResponseEntity.ok().body(new BaseResponse<>(200, "지출 상세 조회에 성공했습니다.", response));
     }
+
+    @Operation(summary = "Expenditures 삭제 API", responses = {
+            @ApiResponse(responseCode = "200")
+    })
+    @Tag(name = "Expenditures")
+    @DeleteMapping("/{expenditureId}")
+    public ResponseEntity expenditureDelete(@PathVariable Long expenditureId, @AuthenticationPrincipal User user) {
+        expenditureService.expenditureDelete(expenditureId, user);
+
+        return ResponseEntity.ok().body(new BaseResponse<>(200, "지출 삭제에성공했습니다."));
+    }
 }

--- a/src/main/java/com/wanted/budgetmanagement/api/expenditure/service/ExpenditureService.java
+++ b/src/main/java/com/wanted/budgetmanagement/api/expenditure/service/ExpenditureService.java
@@ -122,4 +122,23 @@ public class ExpenditureService {
 
         return new ExpenditureDetailResponse(expenditure.getMemo(), expenditure.getPeriod(), expenditure.getCategory().getName(), expenditure.isExcludingTotal(), expenditure.getMoney());
     }
+
+    /**
+     * 지출 삭제
+     * expenditureId로 지출을 삭제한다.
+     * 존재하지 않는 expenditureId가 들어오면 예외 발생,
+     * 삭제할 지출의 유저와 다를경우 예외 발생
+     * @param expenditureId
+     * @param user
+     */
+    @Transactional
+    public void expenditureDelete(Long expenditureId, User user) {
+        Expenditure expenditure = expenditureRepository.findById(expenditureId).orElseThrow(() -> new BaseException(NON_EXISTENT_EXPENDITURE));
+
+        if (expenditure.getUser().getId() != user.getId()) {
+            throw new BaseException(FORBIDDEN_USER);
+        }
+
+        expenditureRepository.delete(expenditure);
+    }
 }

--- a/src/test/java/com/wanted/budgetmanagement/api/expenditure/service/ExpenditureServiceTest.java
+++ b/src/test/java/com/wanted/budgetmanagement/api/expenditure/service/ExpenditureServiceTest.java
@@ -255,4 +255,53 @@ class ExpenditureServiceTest {
         assertThatThrownBy(() -> expenditureService.expenditureDetail(expenditureId, failUser)).hasMessage("권한이 없는 유저입니다.");
 
     }
+
+    @DisplayName("지출 삭제 성공")
+    @Test
+    void expenditureDelete() {
+        // given
+        LocalDate date = LocalDate.parse("2023-11-11");
+        BudgetCategory category = new BudgetCategory(2L, "교통");
+        User user = new User(1L, "email@gmail.com", "password", null);
+        Expenditure expenditure = new Expenditure(1L, "memo", date, category, user, false, 20000L);
+        Long expenditureId = 1L;
+
+        // stub
+        when(expenditureRepository.findById(expenditureId)).thenReturn(Optional.of(expenditure));
+
+        // when
+        expenditureService.expenditureDelete(expenditureId, user);
+        // then
+    }
+
+    @DisplayName("존재하지 않는 지출 아이디로 인한 지출 삭제 실패")
+    @Test
+    void expenditureDeleteFail() {
+        // given
+        User user = new User(1L, "email@gmail.com", "password", null);
+        Long expenditureId = 1L;
+
+        // stub
+        // when
+        // then
+        assertThatThrownBy(() -> expenditureService.expenditureDelete(expenditureId, user)).hasMessage("존재하지 않는 지출입니다.");
+    }
+
+    @DisplayName("삭제할 지출의 유저와 다른 유저로 인한 지출 삭제 실패")
+    @Test
+    void expenditureDeleteFail2() {
+        LocalDate date = LocalDate.parse("2023-11-11");
+        BudgetCategory category = new BudgetCategory(2L, "교통");
+        User user = new User(1L, "email@gmail.com", "password", null);
+        Expenditure expenditure = new Expenditure(1L, "memo", date, category, user, false, 20000L);
+        Long expenditureId = 1L;
+        User failUser = new User(2L, "email2@gmail.com", "password", null);
+
+        // stub
+        when(expenditureRepository.findById(expenditureId)).thenReturn(Optional.of(expenditure));
+
+        // when
+        // then
+        assertThatThrownBy(() -> expenditureService.expenditureDelete(expenditureId, failUser)).hasMessage("권한이 없는 유저입니다.");
+    }
 }

--- a/src/test/java/com/wanted/budgetmanagement/domain/expenditure/repository/ExpenditureRepositoryTest.java
+++ b/src/test/java/com/wanted/budgetmanagement/domain/expenditure/repository/ExpenditureRepositoryTest.java
@@ -77,4 +77,24 @@ class ExpenditureRepositoryTest {
         );
 
     }
+
+    @DisplayName("지출 삭제 성공")
+    @Test
+    void expenditureDelete() {
+        // given
+        BudgetCategory category = new BudgetCategory(1L, "식비");
+        categoryRepository.save(category);
+        User user = new User(1L, "email@gmail.com", "password", null);
+        LocalDate date = LocalDate.parse("2023-11-11");
+        Expenditure expenditure = new Expenditure(1L, "저녁값 지출", date, category, user, false, 20000L);
+        expenditureRepository.save(expenditure);
+
+        // when
+        expenditureRepository.delete(expenditure);
+        Optional<Expenditure> findExpenditure = expenditureRepository.findById(expenditure.getId());
+
+        // then
+        assertThat(findExpenditure).isEmpty();
+
+    }
 }


### PR DESCRIPTION
## 작업 내용
- 지출 삭제 기능 추가, 지출 삭제 테스트 코드 추가
<br><br>

## 작업 설명
- [`5c48ffd`](https://github.com/ks12b0000/wanted-pre-onboarding-budget-management/pull/27/commits/5c48ffd7ceea399d906d07dc259c3c06407f6cd8): expenditureId로 지출을 삭제한다. 만약 존재하지 않는 expenditureId가 들어오면 NON_EXISTENT_EXPENDITURE(존재하지 않는 지출입니다.) 예외 발생, 삭제할 지출의 유저와 다를경우 FORBIDDEN_USER(권한이 없는 유저입니다.) 예외 발생
- [`8c10b59`](https://github.com/ks12b0000/wanted-pre-onboarding-budget-management/pull/27/commits/8c10b5966d116b5894ad0c2a450768a2c992e6a8): ExpenditureRepository, ExpenditureService에 지출 삭제 성공, 실패 테스트 코드 추가
<br><br>

## 테스트
- 지출 삭제 성공
<img width="1386" alt="스크린샷 2023-11-14 오전 10 58 15" src="https://github.com/ks12b0000/wanted-pre-onboarding-budget-management/assets/102012155/bc7c4730-0648-401a-ab0d-53d22f2da747">

- 지출 삭제 실패
<img width="1386" alt="스크린샷 2023-11-14 오전 10 57 43" src="https://github.com/ks12b0000/wanted-pre-onboarding-budget-management/assets/102012155/8a1d8fa4-c420-4825-b50f-273a12a37f64">
<img width="1386" alt="스크린샷 2023-11-14 오전 10 59 25" src="https://github.com/ks12b0000/wanted-pre-onboarding-budget-management/assets/102012155/5950189c-8816-4847-a8b4-9b5dc19fdaed">
<img width="373" alt="스크린샷 2023-11-14 오전 11 00 08" src="https://github.com/ks12b0000/wanted-pre-onboarding-budget-management/assets/102012155/acf5186b-bde5-48c0-9a9b-707dbbae631b">
