### PR TITLE
feat: 지출 합계 제외 업데이트 기능 추가

### DIFF
--- a/src/main/java/com/wanted/budgetmanagement/api/expenditure/controller/ExpenditureController.java
+++ b/src/main/java/com/wanted/budgetmanagement/api/expenditure/controller/ExpenditureController.java
@@ -83,4 +83,15 @@ public class ExpenditureController {
 
         return ResponseEntity.ok().body(new BaseResponse<>(200, "지출 삭제에성공했습니다."));
     }
+
+    @Operation(summary = "Expenditures 합계 제외 업데이트 API", responses = {
+            @ApiResponse(responseCode = "200")
+    })
+    @Tag(name = "Expenditures")
+    @PatchMapping("/except/{expenditureId}")
+    public ResponseEntity expenditureExceptUpdate(@PathVariable Long expenditureId, @AuthenticationPrincipal User user, @RequestParam boolean excludingTotal) {
+        expenditureService.expenditureExceptUpdate(expenditureId, user, excludingTotal);
+
+        return ResponseEntity.ok().body(new BaseResponse<>(200, "지출 합계 제외 업데이트에 성공했습니다."));
+    }
 }

--- a/src/main/java/com/wanted/budgetmanagement/api/expenditure/service/ExpenditureService.java
+++ b/src/main/java/com/wanted/budgetmanagement/api/expenditure/service/ExpenditureService.java
@@ -141,4 +141,24 @@ public class ExpenditureService {
 
         expenditureRepository.delete(expenditure);
     }
+
+    /**
+     * 지출 합계 제외 업데이트
+     * expenditureId, excludingTotal로 지출 합계 제외를 업데이트한다.
+     * 존재하지 않는 expenditureId가 들어오면 예외 발생,
+     * 업데이트할 지출의 유저와 다를경우 예외 발생
+     * @param expenditureId
+     * @param user
+     * @param excludingTotal : false = 합계 제외 안함, true = 합계 제외 함.
+     */
+    @Transactional
+    public void expenditureExceptUpdate(Long expenditureId, User user, boolean excludingTotal) {
+        Expenditure expenditure = expenditureRepository.findById(expenditureId).orElseThrow(() -> new BaseException(NON_EXISTENT_EXPENDITURE));
+
+        if (expenditure.getUser().getId() != user.getId()) {
+            throw new BaseException(FORBIDDEN_USER);
+        }
+
+        expenditure.excludingTotalUpdate(excludingTotal);
+    }
 }

--- a/src/main/java/com/wanted/budgetmanagement/domain/expenditure/entity/Expenditure.java
+++ b/src/main/java/com/wanted/budgetmanagement/domain/expenditure/entity/Expenditure.java
@@ -51,4 +51,8 @@ public class Expenditure {
         this.period = request.getPeriod();
         this.memo = request.getMemo();
     }
+
+    public void excludingTotalUpdate(boolean excludingTotal) {
+        this.excludingTotal = excludingTotal;
+    }
 }

--- a/src/test/java/com/wanted/budgetmanagement/api/expenditure/service/ExpenditureServiceTest.java
+++ b/src/test/java/com/wanted/budgetmanagement/api/expenditure/service/ExpenditureServiceTest.java
@@ -304,4 +304,58 @@ class ExpenditureServiceTest {
         // then
         assertThatThrownBy(() -> expenditureService.expenditureDelete(expenditureId, failUser)).hasMessage("권한이 없는 유저입니다.");
     }
+
+    @DisplayName("지출 합계 제외 업데이트 성공")
+    @Test
+    void expenditureExceptUpdate() {
+        // given
+        LocalDate date = LocalDate.parse("2023-11-11");
+        BudgetCategory category = new BudgetCategory(2L, "교통");
+        User user = new User(1L, "email@gmail.com", "password", null);
+        Expenditure expenditure = new Expenditure(1L, "memo", date, category, user, false, 20000L);
+        Long expenditureId = 1L;
+
+        // stub
+        when(expenditureRepository.findById(expenditureId)).thenReturn(Optional.of(expenditure));
+
+        // when
+        expenditureService.expenditureExceptUpdate(expenditureId, user, true);
+
+        // then
+        assertThat(expenditure.isExcludingTotal()).isTrue();
+
+    }
+
+    @DisplayName("존재하지 않는 지출 아이디로 인한 지출 합계 제외 업데이트 실패")
+    @Test
+    void expenditureExceptUpdateFail() {
+        // given
+        User user = new User(1L, "email@gmail.com", "password", null);
+        Long expenditureId = 1L;
+
+        // stub
+        // when
+        // then
+        assertThatThrownBy(() -> expenditureService.expenditureExceptUpdate(expenditureId, user, true)).hasMessage("존재하지 않는 지출입니다.");
+
+    }
+
+    @DisplayName("업데이트할 지출의 유저와 다른 유저로 인한 지출 합계 제외 업데이트 실패")
+    @Test
+    void expenditureExceptUpdateFail2() {
+        // given
+        LocalDate date = LocalDate.parse("2023-11-11");
+        BudgetCategory category = new BudgetCategory(2L, "교통");
+        User user = new User(1L, "email@gmail.com", "password", null);
+        Expenditure expenditure = new Expenditure(1L, "memo", date, category, user, false, 20000L);
+        Long expenditureId = 1L;
+        User failUser = new User(2L, "email2@gmail.com", "password", null);
+
+        // stub
+        when(expenditureRepository.findById(expenditureId)).thenReturn(Optional.of(expenditure));
+
+        // then
+        assertThatThrownBy(() -> expenditureService.expenditureExceptUpdate(expenditureId, failUser, true)).hasMessage("권한이 없는 유저입니다.");
+
+    }
 }


### PR DESCRIPTION
## 작업 내용
- 지출 합계 제외 업데이트 기능 추가, 지출 합계 제외 업데이트 테스트 코드 추가.

<br><br>

## 작업 설명
- [`b62d953`](https://github.com/ks12b0000/wanted-pre-onboarding-budget-management/pull/28/commits/b62d9535d8163bbfdedd8e2e4e5e44a7bc74abd5): expenditureId, excludingTotal(false = 지출 합계 제외 안함. true = 지출 합계 제외 함.) 로 지출 합계 제외를 업데이트한다. 존재하지 않는 expenditureId가 들어오면 예외 발생, 업데이트할 지출의 유저와 다를경우 예외 발생
- [`afca982`](https://github.com/ks12b0000/wanted-pre-onboarding-budget-management/pull/28/commits/afca9827e7d36847d253786ff035362bd40c6836): ExpenditureServiceTest에 지출 합계 제외 업데이트 성공, 실패 테스트 코드 추가

<br><br>

## 테스트
- 지출 합계 제외 업데이트 성공
<img width="1393" alt="스크린샷 2023-11-14 오전 11 22 31" src="https://github.com/ks12b0000/wanted-pre-onboarding-budget-management/assets/102012155/d9ca161d-600d-48fe-8e20-13ef547e9530">

- 지출 합계 제외 업데이트 실패
<img width="1384" alt="스크린샷 2023-11-14 오전 11 23 18" src="https://github.com/ks12b0000/wanted-pre-onboarding-budget-management/assets/102012155/4dec2ac6-1f67-4e8e-a587-fa79aec05449">
<img width="1392" alt="스크린샷 2023-11-14 오전 11 23 49" src="https://github.com/ks12b0000/wanted-pre-onboarding-budget-management/assets/102012155/ff15225f-3595-4431-aab6-97ad1bd86802">
<img width="465" alt="스크린샷 2023-11-14 오전 11 24 13" src="https://github.com/ks12b0000/wanted-pre-onboarding-budget-management/assets/102012155/673ffef6-5df9-487d-81f2-51e8f335579f">

