### PR TITLE
feat: 지출 추천 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,9 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 
+	// mail 전송
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/wanted/budgetmanagement/BudgetManagementApplication.java
+++ b/src/main/java/com/wanted/budgetmanagement/BudgetManagementApplication.java
@@ -2,7 +2,9 @@ package com.wanted.budgetmanagement;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class BudgetManagementApplication {
 

--- a/src/main/java/com/wanted/budgetmanagement/api/expenditure/controller/ExpenditureController.java
+++ b/src/main/java/com/wanted/budgetmanagement/api/expenditure/controller/ExpenditureController.java
@@ -1,9 +1,6 @@
 package com.wanted.budgetmanagement.api.expenditure.controller;
 
-import com.wanted.budgetmanagement.api.expenditure.dto.ExpenditureCreateRequest;
-import com.wanted.budgetmanagement.api.expenditure.dto.ExpenditureDetailResponse;
-import com.wanted.budgetmanagement.api.expenditure.dto.ExpenditureListResponse;
-import com.wanted.budgetmanagement.api.expenditure.dto.ExpenditureUpdateRequest;
+import com.wanted.budgetmanagement.api.expenditure.dto.*;
 import com.wanted.budgetmanagement.api.expenditure.service.ExpenditureService;
 import com.wanted.budgetmanagement.domain.user.entity.User;
 import com.wanted.budgetmanagement.global.exception.BaseResponse;
@@ -93,5 +90,16 @@ public class ExpenditureController {
         expenditureService.expenditureExceptUpdate(expenditureId, user, excludingTotal);
 
         return ResponseEntity.ok().body(new BaseResponse<>(200, "지출 합계 제외 업데이트에 성공했습니다."));
+    }
+
+    @Operation(summary = "Expenditures 추천 API", responses = {
+            @ApiResponse(responseCode = "200")
+    })
+    @Tag(name = "Expenditures")
+    @GetMapping("/recommend")
+    public ResponseEntity expenditureRecommend(@AuthenticationPrincipal User user) {
+        ExpenditureRecommendResponse response = expenditureService.expenditureRecommend(user);
+
+        return ResponseEntity.ok().body(new BaseResponse<>(200, "지출 추천에 성공했습니다.", response));
     }
 }

--- a/src/main/java/com/wanted/budgetmanagement/api/expenditure/dto/ExpenditureRecommend.java
+++ b/src/main/java/com/wanted/budgetmanagement/api/expenditure/dto/ExpenditureRecommend.java
@@ -1,0 +1,19 @@
+package com.wanted.budgetmanagement.api.expenditure.dto;
+
+import com.wanted.budgetmanagement.domain.budgetCategory.entity.BudgetCategory;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Setter
+public class ExpenditureRecommend {
+
+    private BudgetCategory category;
+
+    private long todayExpenditurePossibleMoney;
+
+}

--- a/src/main/java/com/wanted/budgetmanagement/api/expenditure/dto/ExpenditureRecommendResponse.java
+++ b/src/main/java/com/wanted/budgetmanagement/api/expenditure/dto/ExpenditureRecommendResponse.java
@@ -1,0 +1,21 @@
+package com.wanted.budgetmanagement.api.expenditure.dto;
+
+import com.wanted.budgetmanagement.domain.budgetCategory.entity.BudgetCategory;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExpenditureRecommendResponse {
+
+    List<ExpenditureRecommend> recommendList;
+
+    private long todayExpenditurePossibleTotal;
+
+    private String message;
+
+}

--- a/src/main/java/com/wanted/budgetmanagement/api/expenditure/service/ExpenditureSchedulerService.java
+++ b/src/main/java/com/wanted/budgetmanagement/api/expenditure/service/ExpenditureSchedulerService.java
@@ -1,0 +1,43 @@
+package com.wanted.budgetmanagement.api.expenditure.service;
+
+import com.wanted.budgetmanagement.api.expenditure.dto.ExpenditureRecommendResponse;
+import com.wanted.budgetmanagement.domain.user.entity.User;
+import com.wanted.budgetmanagement.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Component
+public class ExpenditureSchedulerService {
+
+    private final ExpenditureService expenditureService;
+
+    private final UserRepository userRepository;
+
+    private final JavaMailSender mailSender;
+
+    @Transactional
+//    @Scheduled(initialDelay = 1000 ,fixedDelay = 60 * 60 * 1000)
+    @Scheduled(cron = "0 0 8 * * ?", zone = "Asia/Seoul")
+    public void expenditureRecommendScheduler() {
+        List<User> users = userRepository.findAll();
+        for (int i = 0; i < users.size(); i++) {
+            User user = users.get(i);
+            SimpleMailMessage mailMessage = new SimpleMailMessage();
+            ExpenditureRecommendResponse response = expenditureService.expenditureRecommend(user);
+
+            mailMessage.setTo(user.getEmail());
+            mailMessage.setSubject("안녕하세요! BudgetManagement 서비스 입니다. 오늘의 지출 금액을 추천해드려요!");
+            mailMessage.setText(response.getMessage());
+            mailSender.send(mailMessage);
+        }
+
+    }
+}

--- a/src/main/java/com/wanted/budgetmanagement/domain/budget/repository/BudgetRepository.java
+++ b/src/main/java/com/wanted/budgetmanagement/domain/budget/repository/BudgetRepository.java
@@ -2,6 +2,7 @@ package com.wanted.budgetmanagement.domain.budget.repository;
 
 import com.wanted.budgetmanagement.api.budget.dto.BudgetRecommendListResponse;
 import com.wanted.budgetmanagement.api.budget.dto.BudgetRecommendResponse;
+import com.wanted.budgetmanagement.api.expenditure.dto.ExpenditureRecommend;
 import com.wanted.budgetmanagement.domain.budget.entity.Budget;
 import com.wanted.budgetmanagement.domain.budgetCategory.entity.BudgetCategory;
 import com.wanted.budgetmanagement.domain.user.entity.User;
@@ -21,4 +22,11 @@ public interface BudgetRepository extends JpaRepository<Budget,Long> {
             "from Budget " +
             "group by category")
     List<BudgetRecommendResponse> findByAverage(@Param("totalAmount") long totalAmount);
+
+    @Query("select new com.wanted.budgetmanagement.api.expenditure.dto.ExpenditureRecommend(" +
+            "category, round(sum(money) / :period, -3) as todayExpenditurePossibleMoney) " +
+            "from Budget " +
+            "where user = :user AND period = :start " +
+            "group by category")
+    List<ExpenditureRecommend> findByExpenditureRecommend(@Param("user") User user, @Param("start") LocalDate start, @Param("period") long period);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,7 +22,7 @@ spring:
       maximum-pool-size: 5
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: true
     properties:
       hibernate:
@@ -33,6 +33,19 @@ spring:
   sql:
     init:
       mode: always
+
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          timeout: 5000
+          starttls:
+            enable: true
 
 JWT_SECRET_KEY: ${JWT_SECRET_KEY}
 JWT_ISSUER: ${JWT_ISSUER}


### PR DESCRIPTION
## 작업 내용
- 지출 추천 기능 추가, 지출 추천 기능 스케줄러 추가, 메일 전송 추가

<br><br>

## 작업 설명
- [`1b39d3c`](https://github.com/ks12b0000/BudgetManagementProject/pull/30/commits/1b39d3caa65398adc639509f4d50c75434ef4a05): 현재 날짜와 이번 달 마지막 날짜의 차이를 구해 앞으로 남은 카테고리별 예산을 구해서 오늘의 카테고리별 적정 지출 금액 계산을 한다. 이번 달에 예산을 초과한 카테고리가 하나도 없다면 첫 번째 "절약을 잘 실천하고 계시네요! 앞으로 남은 날도 절약을 위해 화이팅!"을 출력하고, 이번 달에 예산을 초과한 카테고리가 하나라도 있으면 예산을 초과한 카테고리 이름 + "에 예산을 초과하셨네요! 오늘은 최소 20,000원 이하의 금액만 사용하시는걸 권장해 드리고 앞으로 남은 날은 조금 아껴 쓰셔야 하겠어요!"를 출력한다.
- [`f771dfc`](https://github.com/ks12b0000/BudgetManagementProject/pull/30/commits/f771dfcd7ad03b30cb4c2dae1cb0338f57d1eb9d): 스케줄러를 추가해 08:00시마다 위 지출 추천 기능을 통해 모든 유저한테 이메일로 오늘의 적정 지출 금액과 메시지를 보내준다.
- [`a6210b3`](https://github.com/ks12b0000/BudgetManagementProject/pull/30/commits/a6210b3c96c37853273be0935cb549a45e0dfafb): 이메일 전송 dependencies 추가
- [`4c185e1`](https://github.com/ks12b0000/BudgetManagementProject/pull/30/commits/4c185e1715550accce0c38ade50776f6516b3739): yml에 이메일 관련 코드 추가
- [`c17f54a`](https://github.com/ks12b0000/BudgetManagementProject/pull/30/commits/c17f54a24b00540ab5f182650818c25d0b57e896): ExpenditureServiceTest에 오늘의 지출 추천 성공 테스트 코드 추가

<br><br>

## 테스트
- 오늘의 지출 추천 성공
<img width="1384" alt="스크린샷 2023-11-15 오후 11 43 17" src="https://github.com/ks12b0000/BudgetManagementProject/assets/102012155/c657b8fd-db4d-40f2-918d-ab9f1f730457">
<img width="1374" alt="스크린샷 2023-11-15 오후 11 44 04" src="https://github.com/ks12b0000/BudgetManagementProject/assets/102012155/8c8f1f81-c335-4918-9fde-164d6d375a8b">

<img width="249" alt="스크린샷 2023-11-16 오후 6 35 58" src="https://github.com/ks12b0000/BudgetManagementProject/assets/102012155/7b5a950c-3af4-4e03-8668-fa2fb3cbace7">

